### PR TITLE
Updated build_test workflow to build all targets

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -48,6 +48,6 @@ jobs:
         with:
           BUILD_TYPE: Release
           CMAKE_BUILD_PARALLEL_LEVEL: 4
-          CMAKE_BUILD_ARGS: "-DBUILD_SHARED_LIBS=ON -DANIRA_WITH_TESTS=ON"
+          CMAKE_BUILD_ARGS: "-DBUILD_SHARED_LIBS=ON -DANIRA_WITH_TESTS=ON -DANIRA_BUILD_EXAMPLES=ON"
       - name: test
         uses: ./.github/actions/test


### PR DESCRIPTION
To prevent issue #19 and ensure all examples are functional after a commit, we should build all targets as part of the build_test.yml workflow