### PR TITLE
Fix Git Version Extraction in Submodule Context

### DIFF
--- a/.github/workflows/build_benchmark.yml
+++ b/.github/workflows/build_benchmark.yml
@@ -47,7 +47,11 @@ jobs:
         run: |
           if [ "${{ matrix.name }}" == "Linux-x86_64" ]; then
             sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libfreetype6-dev libasound2-dev
+            # Fix the juce bug with ft2build.h not found
+            ln -s /usr/include/freetype2/ft2build.h /usr/include/ft2build.h
+            ln -s /usr/include/freetype2/freetype /usr/include/freetype
           fi
+      
       - name: build
         uses: ./.github/actions/build
         with:

--- a/.github/workflows/build_benchmark.yml
+++ b/.github/workflows/build_benchmark.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash
         run: |
           if [ "${{ matrix.name }}" == "Linux-x86_64" ]; then
-            sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libfreetype6-dev libasound2-dev
+            sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libfreetype6-dev libasound2-dev libfontconfig1-dev
             # Fix the juce bug with ft2build.h not found
             sudo ln -s /usr/include/freetype2/ft2build.h /usr/include/ft2build.h
             sudo ln -s /usr/include/freetype2/freetype /usr/include/freetype

--- a/.github/workflows/build_benchmark.yml
+++ b/.github/workflows/build_benchmark.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-      - develop
 
 env:
   SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/build_benchmark.yml
+++ b/.github/workflows/build_benchmark.yml
@@ -48,8 +48,8 @@ jobs:
           if [ "${{ matrix.name }}" == "Linux-x86_64" ]; then
             sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libfreetype6-dev libasound2-dev
             # Fix the juce bug with ft2build.h not found
-            ln -s /usr/include/freetype2/ft2build.h /usr/include/ft2build.h
-            ln -s /usr/include/freetype2/freetype /usr/include/freetype
+            sudo ln -s /usr/include/freetype2/ft2build.h /usr/include/ft2build.h
+            sudo ln -s /usr/include/freetype2/freetype /usr/include/freetype
           fi
       
       - name: build

--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -1,0 +1,59 @@
+name: build_examples
+
+on:
+  workflow_call:
+  workflow_dispatch: # lets you run a build from github.com
+  # Runs the workflow on all push events
+  pull_request:
+    branches:
+      - main
+
+env:
+  SCCACHE_GHA_ENABLED: "true"
+
+# When pushing new commits, cancel any workflows with the same name on that branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_test:
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
+      matrix:
+        include:
+          - name: Linux-x86_64
+            os: ubuntu-latest
+          - name: macOS-x86_64
+            os: macOS-latest
+          - name: macOS-arm64
+            os: macOS-latest
+          - name: Windows-x86_64
+            os: windows-latest
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: get repo and submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: setup
+        uses: ./.github/actions/setup
+      - name: add juce deps
+        shell: bash
+        run: |
+          if [ "${{ matrix.name }}" == "Linux-x86_64" ]; then
+            sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libfreetype6-dev libasound2-dev libfontconfig1-dev
+            # Fix the juce bug with ft2build.h not found
+            sudo ln -s /usr/include/freetype2/ft2build.h /usr/include/ft2build.h
+            sudo ln -s /usr/include/freetype2/freetype /usr/include/freetype
+          fi   
+      - name: build
+        uses: ./.github/actions/build
+        with:
+          BUILD_TYPE: Release
+          CMAKE_BUILD_PARALLEL_LEVEL: 4
+          TARGETS: (anira-clap-plugin-example anira-juce-plugin-example_All minimal-libtorch minimal-onnxruntime minimal-tflite)
+          CMAKE_BUILD_ARGS: "-DBUILD_SHARED_LIBS=ON -DANIRA_WITH_EXAMPLES=ON"

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches:
       - main
-      - develop
 
 env:
   SCCACHE_GHA_ENABLED: "true"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,12 @@ option(ANIRA_WITH_CONTROLLED_BLOCKING "Use of controlled blocking operation for 
 # ==============================================================================
 
 execute_process(COMMAND git describe --dirty
-                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                 OUTPUT_VARIABLE PROJECT_VERSION_FULL
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 execute_process(COMMAND git describe --tags --abbrev=0
-                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                 OUTPUT_VARIABLE PROJECT_VERSION_SHORT
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![build_test](https://github.com/anira-project/anira/actions/workflows/build_test.yml/badge.svg)
 ![build_benchmark](https://github.com/anira-project/anira/actions/workflows/build_benchmark.yml/badge.svg)
+![build_examples](https://github.com/anira-project/anira/actions/workflows/build_examples.yml/badge.svg)
 ![on_tag](https://github.com/anira-project/anira/actions/workflows/on_tag.yml/badge.svg)
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,4 @@
+# TODOs
+
+- [ ] Trigger `ldconfig` in the .deb package
+- [ ] Run the examples as tests in CI

--- a/examples/juce-audio-plugin/CMakeLists.txt
+++ b/examples/juce-audio-plugin/CMakeLists.txt
@@ -29,7 +29,7 @@ include(FetchContent)
 
 FetchContent_Declare(JUCE
         GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
-        GIT_TAG 8.0.4
+        GIT_TAG 8.0.6
         GIT_PROGRESS TRUE
 )
 FetchContent_MakeAvailable(JUCE)

--- a/examples/juce-audio-plugin/CMakeLists.txt
+++ b/examples/juce-audio-plugin/CMakeLists.txt
@@ -100,7 +100,6 @@ target_compile_definitions(${TARGET_NAME}
     JUCE_WEB_BROWSER=0  # If you remove this, add `NEEDS_WEB_BROWSER TRUE` to the `juce_add_plugin` call
     JUCE_USE_CURL=0     # If you remove this, add `NEEDS_CURL TRUE` to the `juce_add_plugin` call
     JUCE_VST3_CAN_REPLACE_VST2=0
-    DONT_SET_USING_JUCE_NAMESPACE=1
 
     # Backend-specific definitions
     $<$<BOOL:${BACKEND_LIBTORCH}>:USE_LIBTORCH>


### PR DESCRIPTION
Updated CMake to use `CMAKE_CURRENT_SOURCE_DIR` instead of `CMAKE_SOURCE_DIR` for Git version extraction. This ensures that version information is correctly retrieved when the project is included as a submodule