### PR TITLE
Bugfix: Potential race condition in the InferenceThread

### DIFF
--- a/include/anira/scheduler/InferenceThread.h
+++ b/include/anira/scheduler/InferenceThread.h
@@ -18,7 +18,7 @@ namespace anira {
 class ANIRA_API InferenceThread : public HighPriorityThread {
 public:
     InferenceThread(moodycamel::ConcurrentQueue<InferenceData>& next_inference);
-    ~InferenceThread() override = default;
+    ~InferenceThread() override;
 
     bool execute();
 

--- a/src/scheduler/InferenceThread.cpp
+++ b/src/scheduler/InferenceThread.cpp
@@ -7,6 +7,10 @@ InferenceThread::InferenceThread(moodycamel::ConcurrentQueue<InferenceData>& nex
 {
 }
 
+InferenceThread::~InferenceThread() {
+    stop();
+}
+
 void InferenceThread::run() {
     while (!should_exit()) {
         constexpr std::array<int, 2> iterations = {4, 32};


### PR DESCRIPTION
Issue pointed out by @marcello-sonnox in his [fork](https://github.com/marcello-sonnox/anira/commit/e73587a43384804a41ad43ef40640e0e23044bc5):

Preventing a race condition in the InferenceThread:
- The derived class's context was being destroyed before the base class destructor signalled the thread to stop, which means there is the chance for the thread to call deleted context while running