### PR TITLE
ci: distinct concurrency groups for reusable test workflows

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -15,8 +15,12 @@ env:
   SCCACHE_GHA_ENABLED: "true"
 
 # When pushing new commits, cancel any workflows with the same name on that branch
+# Hardcode the workflow name (not ${{ github.workflow }}): when on_tag.yml calls this
+# as a reusable workflow, github.workflow becomes "on_tag" — shared with the other
+# reusable test workflow, so cancel-in-progress would cancel one of them. A literal
+# keeps the group distinct in both the standalone (PR/push) and reused (tag) cases.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: build_test-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_test_mobile.yml
+++ b/.github/workflows/build_test_mobile.yml
@@ -27,8 +27,12 @@ on:
 env:
   SCCACHE_GHA_ENABLED: "true"
 
+# Hardcode the workflow name (not ${{ github.workflow }}): when on_tag.yml calls this
+# as a reusable workflow, github.workflow becomes "on_tag" — shared with build_test,
+# so cancel-in-progress would cancel one of them. A literal keeps the group distinct
+# in both the standalone (PR/push) and reused (tag) cases.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: build_test_mobile-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
When on_tag.yml calls build_test and build_test_mobile as reusable workflows, `github.workflow` resolves to "on_tag" for both, so their identical concurrency group collided and cancel-in-progress cancelled build_test_mobile — blocking the gated release jobs on the v2.2.0 tag. Hardcode a per-workflow literal group. CI-only.