### PR TITLE
fix(scheduler): prepare() crash and hang for non-streamable tensor configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Hang in `SessionElement::prepare()` for generator-style configs with no streamable input (all inputs are control parameters, outputs are streamed): the relative buffer/rate ratios divided by the reference input tensor's preprocess size — 0 for a non-streamable input — and the resulting `inf` never left the smaller-buffer countdown loop. The reference stream (new `HostConfig::get_reference_size()`) now falls back from the configured reference input to the first streamable input, then to the first streamable output.
 - Segfault in `SessionElement::prepare()` when the host allows smaller buffers and **all** output tensors are non-streamable (e.g. analysis models whose results leave through a custom backend): the smaller-buffer pass collected adjusted latencies for streamable outputs only, leaving the vector empty for `sync_latencies()` to index. The vector now stays index-aligned with the output tensors (non-streamable outputs contribute zero latency), which also corrects latency assignment for configs mixing streamable and non-streamable outputs.
 
 ## [v2.2.1] - 2026-07-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Segfault in `SessionElement::prepare()` when the host allows smaller buffers and **all** output tensors are non-streamable (e.g. analysis models whose results leave through a custom backend): the smaller-buffer pass collected adjusted latencies for streamable outputs only, leaving the vector empty for `sync_latencies()` to index. The vector now stays index-aligned with the output tensors (non-streamable outputs contribute zero latency), which also corrects latency assignment for configs mixing streamable and non-streamable outputs.
+
 ## [v2.2.1] - 2026-07-04
 
 ### Added

--- a/include/anira/utils/HostConfig.h
+++ b/include/anira/utils/HostConfig.h
@@ -113,9 +113,7 @@ struct ANIRA_API HostConfig {
     float get_relative_buffer_size(const InferenceConfig& inference_config,
                                    size_t tensor_index,
                                    bool input = true) const {
-        float const ratio_buffer_size =
-            m_buffer_size /
-            static_cast<float>(inference_config.get_preprocess_input_size()[m_tensor_index]);
+        float const ratio_buffer_size = m_buffer_size / get_reference_size(inference_config);
         if (input) {
             return static_cast<float>(inference_config.get_preprocess_input_size()[tensor_index]) *
                    ratio_buffer_size;
@@ -149,9 +147,7 @@ struct ANIRA_API HostConfig {
     float get_relative_sample_rate(const InferenceConfig& inference_config,
                                    size_t tensor_index,
                                    bool input = true) const {
-        float const ratio_sample_rate =
-            m_sample_rate /
-            static_cast<float>(inference_config.get_preprocess_input_size()[m_tensor_index]);
+        float const ratio_sample_rate = m_sample_rate / get_reference_size(inference_config);
         if (input) {
             return static_cast<float>(inference_config.get_preprocess_input_size()[tensor_index]) *
                    ratio_sample_rate;
@@ -160,6 +156,35 @@ struct ANIRA_API HostConfig {
                        inference_config.get_postprocess_output_size()[tensor_index]) *
                    ratio_sample_rate;
         }
+    }
+
+    /**
+     * @brief Size of the reference stream used for relative buffer/rate scaling
+     *
+     * The reference is the input tensor selected by m_tensor_index. If that
+     * tensor is non-streamable (preprocess size 0) — e.g. generator-style
+     * models whose inputs are all control parameters — the reference falls
+     * back to the first streamable input, then to the first streamable
+     * output. Without the fallback the ratio computations above divide by
+     * zero, and the resulting inf ends up in SessionElement::prepare()'s
+     * smaller-buffer countdown loop, which never terminates (inf - 1 == inf).
+     *
+     * @param inference_config The inference configuration containing tensor sizes
+     * @return The reference tensor's streamable size, or 1.0f if no tensor is
+     *         streamable (ratios are meaningless then, but stay finite)
+     */
+    float get_reference_size(const InferenceConfig& inference_config) const {
+        const auto& input_sizes = inference_config.get_preprocess_input_size();
+        if (m_tensor_index < input_sizes.size() && input_sizes[m_tensor_index] > 0) {
+            return static_cast<float>(input_sizes[m_tensor_index]);
+        }
+        for (const auto size : input_sizes) {
+            if (size > 0) { return static_cast<float>(size); }
+        }
+        for (const auto size : inference_config.get_postprocess_output_size()) {
+            if (size > 0) { return static_cast<float>(size); }
+        }
+        return 1.0f;
     }
 };
 

--- a/src/scheduler/SessionElement.cpp
+++ b/src/scheduler/SessionElement.cpp
@@ -288,6 +288,11 @@ void SessionElement::prepare(const HostConfig& host_config, std::vector<long> cu
 
                     adjusted_latency.push_back(
                         static_cast<float>(inference_caused_latency + buffer_adaptation));
+                } else {
+                    // Non-streamable outputs carry no latency, but the vector must
+                    // stay index-aligned with the output tensors: sync_latencies and
+                    // the m_latency update below index it per output tensor.
+                    adjusted_latency.push_back(0.f);
                 }
             }
 
@@ -473,7 +478,7 @@ std::vector<unsigned int> SessionElement::sync_latencies(
                 result.push_back(0);  // If no output size, just return 0
             }
         }
-    } else {
+    } else if (latencies.size() == 1) {
         result.push_back(std::ceil(latencies[0]));  // If only one output size, just return the
                                                     // calculated value
     }

--- a/src/scheduler/SessionElement.cpp
+++ b/src/scheduler/SessionElement.cpp
@@ -207,9 +207,7 @@ void SessionElement::prepare(const HostConfig& host_config, std::vector<long> cu
                     m_inference_config.get_postprocess_output_size()[greatest_buffer_size_index]);
         }
         min_config.m_buffer_size =
-            buffer_size_ratio *
-            static_cast<float>(
-                m_inference_config.get_preprocess_input_size()[host_config.m_tensor_index]);
+            buffer_size_ratio * host_config.get_reference_size(m_inference_config);
 
         while (--greatest_buffer_size > 0) {
             float buffer_size_ratio;
@@ -226,9 +224,7 @@ void SessionElement::prepare(const HostConfig& host_config, std::vector<long> cu
                             .get_postprocess_output_size()[greatest_buffer_size_index]);
             }
             adjusted_config.m_buffer_size =
-                buffer_size_ratio *
-                static_cast<float>(
-                    m_inference_config.get_preprocess_input_size()[host_config.m_tensor_index]);
+                buffer_size_ratio * host_config.get_reference_size(m_inference_config);
 
             std::vector<float> adjusted_latency;
             for (size_t i = 0; i < m_inference_config.get_tensor_output_shape().size(); ++i) {

--- a/test/scheduler/test_SessionElement.cpp
+++ b/test/scheduler/test_SessionElement.cpp
@@ -574,3 +574,55 @@ TEST(SessionElementNonStreamableOutputTest, PrepareWithSmallerBuffersDoesNotCras
     ASSERT_EQ(session.m_latency.size(), 1u);
     ASSERT_EQ(session.m_latency[0], 0u) << "A non-streamable output carries no latency.";
 }
+
+namespace {
+// Leaked deliberately (same pattern as ClearDeadlockFixture above): on
+// regression prepare() never returns, and the detached thread must not touch
+// a destroyed fixture when the test gives up.
+struct OutputOnlyPrepareFixture {
+    InferenceConfig m_inference_config{
+        std::vector<ModelData>{ModelData("placeholder", anira::InferenceBackend::CUSTOM)},
+        std::vector<TensorShape>{TensorShape({{1, 4}}, {{1, 2048}})},
+        ProcessingSpec({1}, {1}, {0}, {2048}),
+        10.f,
+        0,
+        true};
+    PrePostProcessor m_pp_processor{m_inference_config};
+    InferenceQueue m_inference_queue;
+    SessionElement m_session{0,
+                             m_pp_processor,
+                             m_inference_config,
+                             moodycamel::ProducerToken(m_inference_queue)};
+    std::atomic<bool> m_prepared{false};
+};
+}  // namespace
+
+// Regression: generator-style configs — no streamable input, only streamable
+// outputs — hung prepare() forever when the host allowed smaller buffers. The
+// relative buffer-size ratio divided by the reference input tensor's
+// preprocess size, which is 0 for a non-streamable input; the resulting inf
+// never left the smaller-buffer countdown loop (inf - 1 == inf). The
+// reference stream now falls back to the first streamable tensor.
+TEST(SessionElementOutputOnlyTest, PrepareWithSmallerBuffersTerminates) {
+    auto* fixture = new OutputOnlyPrepareFixture();
+
+    std::thread([fixture] {
+        fixture->m_session.prepare(HostConfig(512, 48000, true));
+        fixture->m_prepared.store(true, std::memory_order_release);
+    }).detach();
+
+    auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (!fixture->m_prepared.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    ASSERT_TRUE(fixture->m_prepared.load(std::memory_order_acquire))
+        << "prepare() did not terminate for an output-only config with "
+           "allow_smaller_buffers (relative buffer ratio divided by the "
+           "non-streamable reference input's size 0).";
+    ASSERT_EQ(fixture->m_session.m_latency.size(), 1u);
+    ASSERT_EQ(fixture->m_session.m_latency[0], 2527u)
+        << "Latency should scale the 2048-sample output chunk against the "
+           "512-sample host buffer via the streamable-output reference.";
+}

--- a/test/scheduler/test_SessionElement.cpp
+++ b/test/scheduler/test_SessionElement.cpp
@@ -547,3 +547,30 @@ TEST(SessionElementClearTest, ClearWithBlockingRatioDoesNotFreeze) {
         << "SessionElement::clear() deadlocked draining the done-semaphores "
            "(blind acquire on a semaphore with count 0).";
 }
+
+// Regression: a config whose output tensors are ALL non-streamable (e.g. an
+// analysis model whose result leaves through a custom backend, with only a
+// control-value output tensor) crashed prepare() when the host allowed
+// smaller buffers: the smaller-buffer pass collected adjusted latencies for
+// streamable outputs only, so the vector stayed empty and sync_latencies()
+// dereferenced latencies[0].
+TEST(SessionElementNonStreamableOutputTest, PrepareWithSmallerBuffersDoesNotCrash) {
+    InferenceConfig inference_config(
+        std::vector<ModelData>{ModelData("placeholder", anira::InferenceBackend::CUSTOM)},
+        std::vector<TensorShape>{TensorShape({{1, 2048}, {1, 1}}, {{1, 1}})},
+        ProcessingSpec({1, 1}, {1}, {2048, 0}, {0}),
+        10.f,
+        0,
+        true);
+    PrePostProcessor pp_processor(inference_config);
+    InferenceQueue inference_queue;
+    SessionElement session(0,
+                           pp_processor,
+                           inference_config,
+                           moodycamel::ProducerToken(inference_queue));
+
+    session.prepare(HostConfig(512, 48000, true));
+
+    ASSERT_EQ(session.m_latency.size(), 1u);
+    ASSERT_EQ(session.m_latency[0], 0u) << "A non-streamable output carries no latency.";
+}


### PR DESCRIPTION
Two `SessionElement::prepare()` defects surfaced by a config family the existing examples never exercise — models whose results do not leave through streamed output tensors (found while building the anira-asr-example: streaming Nemotron ASR via a custom backend, where the output is text).

## 1. Segfault: all output tensors non-streamable (`28c0ef5`)

With `allow_smaller_buffers` enabled, the smaller-buffer pass collected adjusted latencies **for streamable outputs only**. If every output tensor is non-streamable (e.g. audio in, a control/counter tensor out, transcript via custom backend), the vector stayed empty and `sync_latencies()` dereferenced `latencies[0]` → segfault on the first `prepare()`. Configs mixing streamable and non-streamable outputs silently paired latencies with the wrong tensors for the same reason.

**Fix:** push an explicit 0 for non-streamable outputs so the vector stays index-aligned with the output tensor list (mirroring `calculate_latency()`), and guard `sync_latencies()` against empty input.

## 2. Hang: no streamable input at all (`1278628`)

`HostConfig::get_relative_buffer_size()/get_relative_sample_rate()` divide by the reference input tensor's preprocess size — 0 when that input is non-streamable. For generator-style configs (inputs are all control parameters, outputs are streamed) the ratio becomes `inf`, and `prepare()`'s smaller-buffer countdown loop never terminates (`inf - 1 == inf`): a hard hang with `allow_smaller_buffers`, meaningless latencies without.

**Fix:** new `HostConfig::get_reference_size()` — the configured reference input when streamable, else the first streamable input, else the first streamable output. Used by both relative getters and `prepare()`'s min/adjusted buffer math so all scaling shares one reference. The fallback only engages for configs that were previously broken.

## Verification

- Two regression tests added (`test_SessionElement.cpp`): the first segfaulted (exit 139) and the second hit its 10 s deadline on unfixed `main`; both pass with the fixes.
- Full suite: **181/181 tests pass** (macOS arm64, ONNX backend only). The parameterized `LatencyStructAndRingbuffers` cases assert exact latencies/struct counts/buffer sizes and are unchanged — all-streamable configs take identical code paths.
- CHANGELOG entries added per repo policy.