### PR TITLE
Move every ring-buffer access on the real-time path to the block API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ set(TANH_WITH_INSTALL ${ANIRA_WITH_INSTALL})
 FetchContent_Declare(
     tanh-lib
     GIT_REPOSITORY https://github.com/tanh-lab/tanh-lib.git
-    GIT_TAG v0.0.3
+    GIT_TAG f38e1d83f1f986c4922c297a08660aa050092940
 )
 FetchContent_MakeAvailable(tanh-lib)
 

--- a/include/anira/utils/helperFunctions.h
+++ b/include/anira/utils/helperFunctions.h
@@ -114,9 +114,7 @@ static void push_buffer_to_ringbuffer(BufferF const& buffer, RingBuffer& ringbuf
         throw std::invalid_argument("Ring buffer is not initialized, cannot push samples.");
     }
     for (size_t i = 0; i < buffer.get_num_channels(); i++) {
-        for (size_t j = 0; j < buffer.get_num_samples(); j++) {
-            ringbuffer.push_sample(i, buffer.get_sample(i, j));
-        }
+        ringbuffer.push_block(i, buffer.get_read_pointer(i), buffer.get_num_samples());
     }
 }
 

--- a/src/PrePostProcessor.cpp
+++ b/src/PrePostProcessor.cpp
@@ -6,7 +6,6 @@
 
 #include <cassert>
 #include <cstddef>
-#include <utility>
 #include <vector>
 
 namespace anira {

--- a/src/PrePostProcessor.cpp
+++ b/src/PrePostProcessor.cpp
@@ -94,12 +94,10 @@ void PrePostProcessor::post_process(std::vector<BufferF>& input,
 void PrePostProcessor::pop_samples_from_buffer(RingBuffer& input,
                                                BufferF& output,
                                                size_t num_samples) {
+    // The output buffer is always a single channel buffer; channel i of the ring
+    // buffer lands at [i * num_samples, (i + 1) * num_samples).
     for (size_t i = 0; i < input.get_num_channels(); i++) {
-        for (size_t j = 0; j < num_samples; j++) {
-            output.set_sample(0, j + (i * num_samples), input.pop_sample(i));  // The output buffer
-                                                                               // is always a single
-                                                                               // channel buffer
-        }
+        input.pop_block(i, output.get_write_pointer(0, i * num_samples), num_samples);
     }
 }
 
@@ -115,20 +113,13 @@ void PrePostProcessor::pop_samples_from_buffer(RingBuffer& input,
                                                size_t num_new_samples,
                                                size_t num_old_samples,
                                                size_t offset) {
-    int const num_total_samples = static_cast<int>(num_new_samples + num_old_samples);
+    // Window layout per channel: [num_old history samples][num_new fresh samples].
+    // The history is the num_old_samples that precede the read position, so it
+    // has to be read before pop_block() advances it.
     for (size_t i = 0; i < input.get_num_channels(); i++) {
-        // int j is important to be signed, because it is used in the condition j >= 0
-        for (int j = num_total_samples - 1; j >= 0; j--) {
-            if (std::cmp_greater_equal(j, num_old_samples)) {
-                output.set_sample(0,
-                                  (size_t)(num_total_samples - j + num_old_samples - 1) + offset,
-                                  input.pop_sample(i));
-            } else {
-                output.set_sample(0,
-                                  (size_t)j + offset,
-                                  input.get_past_sample(i, num_total_samples - (size_t)j));
-            }
-        }
+        float* window = output.get_write_pointer(0, offset);
+        input.peek_past_block(i, window, num_old_samples);
+        input.pop_block(i, window + num_old_samples, num_new_samples);
     }
 }
 
@@ -152,9 +143,7 @@ void PrePostProcessor::push_samples_to_buffer(const BufferF& input,
                                               RingBuffer& output,
                                               size_t num_samples) {
     for (size_t i = 0; i < output.get_num_channels(); i++) {
-        for (size_t j = 0; j < num_samples; j++) {
-            output.push_sample(i, input.get_sample(0, j + (i * num_samples)));
-        }
+        output.push_block(i, input.get_read_pointer(0, i * num_samples), num_samples);
     }
 }
 

--- a/src/scheduler/Context.cpp
+++ b/src/scheduler/Context.cpp
@@ -685,11 +685,10 @@ void Context::new_data_submitted(const std::shared_ptr<SessionElement>& session)
                      channel <
                      session->m_inference_config.get_preprocess_input_channels()[tensor_index];
                      channel++) {
-                    for (size_t i = 0;
-                         i < session->m_inference_config.get_preprocess_input_size()[tensor_index];
-                         i++) {  // Non-streamable parameters have no input size
-                        session->m_send_buffer[tensor_index].pop_sample(channel);
-                    }
+                    // Non-streamable parameters have no input size
+                    session->m_send_buffer[tensor_index].discard(
+                        channel,
+                        session->m_inference_config.get_preprocess_input_size()[tensor_index]);
                 }
             }
             for (size_t tensor_index = 0;
@@ -699,12 +698,11 @@ void Context::new_data_submitted(const std::shared_ptr<SessionElement>& session)
                      channel <
                      session->m_inference_config.get_postprocess_output_channels()[tensor_index];
                      channel++) {
-                    for (size_t i = 0;
-                         i <
-                         session->m_inference_config.get_postprocess_output_size()[tensor_index];
-                         i++) {  // Non-streamable parameters have no output size
-                        session->m_receive_buffer[tensor_index].push_sample(channel, 0.f);
-                    }
+                    // Non-streamable parameters have no output size
+                    session->m_receive_buffer[tensor_index].push_fill(
+                        channel,
+                        0.f,
+                        session->m_inference_config.get_postprocess_output_size()[tensor_index]);
                 }
             }
             LOG_WARNING << "[WARNING] No free inference queue found in session: "

--- a/src/scheduler/InferenceManager.cpp
+++ b/src/scheduler/InferenceManager.cpp
@@ -8,6 +8,7 @@
 #include <anira/utils/InferenceBackend.h>
 #include <anira/utils/Logger.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstddef>
@@ -109,11 +110,9 @@ void InferenceManager::process_input(const float* const* const* input_data, size
             for (size_t channel = 0;
                  channel < m_inference_config.get_preprocess_input_channels()[tensor_index];
                  ++channel) {
-                for (size_t sample = 0; sample < num_samples[tensor_index]; ++sample) {
-                    m_session->m_send_buffer[tensor_index].push_sample(
-                        channel,
-                        input_data[tensor_index][channel][sample]);
-                }
+                m_session->m_send_buffer[tensor_index].push_block(channel,
+                                                                  input_data[tensor_index][channel],
+                                                                  num_samples[tensor_index]);
             }
         } else {
             for (size_t sample = 0; sample < num_samples[tensor_index]; ++sample) {
@@ -130,16 +129,19 @@ size_t* InferenceManager::process_output(float* const* const* output_data, size_
     for (size_t i = 0; i < m_inference_config.get_tensor_output_shape().size(); ++i) {
         if (m_inference_config.get_postprocess_output_size()[i] > 0) {
             int const missing_samples_before = static_cast<int>(m_missing_samples[i]);
-            while (m_missing_samples[i]) {
-                if (m_session->m_receive_buffer[i].get_available_samples(0) > num_samples[i]) {
+            if (m_missing_samples[i] > 0) {
+                // Catch up in one go: drop as many missing samples as can be spared while
+                // still leaving num_samples[i] for this block.
+                size_t const available = m_session->m_receive_buffer[i].get_available_samples(0);
+                if (available > num_samples[i]) {
+                    size_t const to_drop =
+                        std::min(m_missing_samples[i], available - num_samples[i]);
                     for (size_t channel = 0;
                          channel < m_inference_config.get_postprocess_output_channels()[i];
                          ++channel) {
-                        m_session->m_receive_buffer[i].pop_sample(channel);
+                        m_session->m_receive_buffer[i].discard(channel, to_drop);
                     }
-                    m_missing_samples[i]--;
-                } else {
-                    break;  // Exit the loop if not enough samples to pop
+                    m_missing_samples[i] -= to_drop;
                 }
             }
             if (missing_samples_before - m_missing_samples[i] > 0) {
@@ -167,10 +169,10 @@ size_t* InferenceManager::process_output(float* const* const* output_data, size_
                 for (size_t channel = 0;
                      channel < m_inference_config.get_postprocess_output_channels()[tensor_index];
                      ++channel) {
-                    for (size_t sample = 0; sample < num_samples[tensor_index]; ++sample) {
-                        output_data[tensor_index][channel][sample] =
-                            m_session->m_receive_buffer[tensor_index].pop_sample(channel);
-                    }
+                    m_session->m_receive_buffer[tensor_index].pop_block(
+                        channel,
+                        output_data[tensor_index][channel],
+                        num_samples[tensor_index]);
                 }
             } else {
                 for (size_t sample = 0; sample < num_samples[tensor_index]; ++sample) {

--- a/src/scheduler/SessionElement.cpp
+++ b/src/scheduler/SessionElement.cpp
@@ -92,11 +92,10 @@ void SessionElement::clear() {
     for (size_t i = 0; i < m_inference_config.get_tensor_output_shape().size(); ++i) {
         if (m_latency[i] > 0) {
             for (size_t j = 0; j < m_inference_config.get_postprocess_output_channels()[i]; ++j) {
-                for (size_t k = 0;
-                     k < m_latency[i] - m_inference_config.get_internal_model_latency()[i];
-                     ++k) {
-                    m_receive_buffer[i].push_sample(j, 0.f);
-                }
+                m_receive_buffer[i].push_fill(
+                    j,
+                    0.f,
+                    m_latency[i] - m_inference_config.get_internal_model_latency()[i]);
             }
         }
     }
@@ -450,11 +449,10 @@ void SessionElement::prepare(const HostConfig& host_config, std::vector<long> cu
     for (size_t i = 0; i < m_inference_config.get_tensor_output_shape().size(); ++i) {
         if (m_latency[i] > 0) {
             for (size_t j = 0; j < m_inference_config.get_postprocess_output_channels()[i]; ++j) {
-                for (size_t k = 0;
-                     k < m_latency[i] - m_inference_config.get_internal_model_latency()[i];
-                     ++k) {
-                    m_receive_buffer[i].push_sample(j, 0.f);
-                }
+                m_receive_buffer[i].push_fill(
+                    j,
+                    0.f,
+                    m_latency[i] - m_inference_config.get_internal_model_latency()[i]);
             }
         }
     }


### PR DESCRIPTION
# Move every ring-buffer access on the real-time path to the block API

Closes #111.

`RingBuffer` (tanh-lib) has `push_block`/`pop_block`, and this PR pins a
tanh-lib release that adds `push_fill`, `discard` and `peek_past_block`
(tanh-lab/tanh-lib#19). With those, no per-sample ring access is left on the
audio thread or the inference worker:

| where | before | after |
|---|---|---|
| `InferenceManager::process_input` | `push_sample` per sample | `push_block` per channel |
| `InferenceManager::process_output` | `pop_sample` per sample | `pop_block` per channel |
| `process_output` catch-up | `while (missing) pop_sample` | one `discard(min(missing, available − num_samples))` |
| `PrePostProcessor::pop_samples_from_buffer` (all overloads) | `pop_sample`/`get_past_sample` per sample | `peek_past_block` + `pop_block` straight into the tensor |
| `PrePostProcessor::push_samples_to_buffer` | `push_sample` per sample | `push_block` |
| `Context::new_data_submitted` no-free-queue path | pop/push loops | `discard` + `push_fill` |
| `SessionElement` latency priming | `push_sample(0.f)` loop | `push_fill` |
| `helperFunctions::push_buffer_to_ringbuffer` | `push_sample` loop | `push_block` |

The windowed pop reads the history *before* `pop_block` advances the read
position — that is where the `num_old` samples live. The catch-up drop count
equals what the old loop dropped: each iteration reduced `available −
num_samples` by exactly one.

Semantics are unchanged wherever anira calls these: `pop_block` zero-fills an
underflow like `pop_sample`, `push_block`/`push_fill` retain the tail like
`push_sample`. The one divergence is `pop_samples_from_buffer` asked for more
new samples than are available — the old code then read a history window
shifted by the phantom pops; `Context` guards that path before `pre_process`.

## Measurements

BA-Denoise host, M3 Max, Release, 480-sample hop @ 48 kHz (674-float input,
1442-float output tensors), audio-thread cost with the engine on a worker:

| | before | after |
|---|---|---|
| mono, host DSP only | 8.4 µs | 8.6 µs |
| mono + anira | **22–23.5 µs** | **9.6 µs** |
| stereo, host DSP only | 16.9 µs | 16.9 µs |
| stereo + anira | **30.7 µs** | **18.5 µs** |

anira's share of a hop goes from ~14 µs to ~1–1.5 µs; p99 block time roughly
halves and the late count drops (mono 9→5, stereo 12→7).

## Tests

- `test/` suite: 188/188 (incl. `test_RingBuffer`, `test_PrePostProcessorWindow`).
- Randomised differential test of the new tanh-lib ops vs. the per-sample API
  (in the tanh-lib PR).
- Downstream: BA-Denoise's 60 parity/RT-safety tests, bit-identical output.
