### PR TITLE
Clamp a custom latency to the internal model latency

### DIFF
--- a/src/scheduler/SessionElement.cpp
+++ b/src/scheduler/SessionElement.cpp
@@ -408,10 +408,24 @@ void SessionElement::prepare(const HostConfig& host_config, std::vector<long> cu
         }
     }
 
-    // Overwrite with custom latency if provided
+    // Overwrite with custom latency if provided. A custom value replaces the whole
+    // latency, so it must still cover the model's internal latency: the receive
+    // buffer is primed with (latency - internal_model_latency) zeros, and an
+    // unsigned underflow there would prime it with ~4G samples.
     if (custom_latency.size() == m_inference_config.get_tensor_output_shape().size()) {
         for (size_t i = 0; i < custom_latency.size(); ++i) {
-            if (custom_latency[i] >= 0) { m_latency[i] = custom_latency[i]; }
+            if (custom_latency[i] < 0) { continue; }
+            auto const internal_latency =
+                static_cast<unsigned int>(m_inference_config.get_internal_model_latency()[i]);
+            auto requested = static_cast<unsigned int>(custom_latency[i]);
+            if (m_inference_config.get_postprocess_output_size()[i] > 0 &&
+                requested < internal_latency) {
+                LOG_WARNING << "[WARNING] Custom latency " << requested << " for tensor " << i
+                            << " is below the internal model latency " << internal_latency
+                            << "; clamping." << '\n';
+                requested = internal_latency;
+            }
+            m_latency[i] = requested;
         }
     }
 

--- a/test/scheduler/test_InferenceManager.cpp
+++ b/test/scheduler/test_InferenceManager.cpp
@@ -216,6 +216,41 @@ std::string build_test_name(const testing::TestParamInfo<InferenceManagerTest::P
 }
 }  // namespace
 
+// A custom latency replaces the calculated one wholesale, so it must not drop below the
+// model's internal latency: the receive buffer is primed with
+// (latency - internal_model_latency) zeros, and an unsigned underflow there would try to
+// prime ~4G samples. Below-internal values are clamped, above-internal values are kept.
+TEST(InferenceManagerCustomLatency, ClampsToInternalModelLatency) {
+    constexpr size_t k_internal_latency = 100;
+    InferenceConfig inference_config(
+        std::vector<ModelData>{ModelData("placeholder", anira::InferenceBackend::CUSTOM)},
+        std::vector<TensorShape>{TensorShape({{1, 1, 2048}}, {{1, 1, 2048}})},
+        ProcessingSpec({1}, {1}, {2048}, {2048}, {k_internal_latency}),
+        1.f,
+        0,
+        false,
+        0.f,
+        2);
+    HostConfig const host_config(2048, 48000, true);
+
+    {
+        PrePostProcessor pp_processor(inference_config);
+        ContextConfig const context_config(2);
+        InferenceManager inference_manager(pp_processor, inference_config, nullptr, context_config);
+        inference_manager.prepare(host_config, std::vector<long>{10});
+        EXPECT_EQ(inference_manager.get_latency()[0], k_internal_latency)
+            << "custom latency below the internal model latency must be clamped";
+    }
+    {
+        PrePostProcessor pp_processor(inference_config);
+        ContextConfig const context_config(2);
+        InferenceManager inference_manager(pp_processor, inference_config, nullptr, context_config);
+        inference_manager.prepare(host_config, std::vector<long>{500});
+        EXPECT_EQ(inference_manager.get_latency()[0], 500u)
+            << "custom latency above the internal model latency must be kept";
+    }
+}
+
 INSTANTIATE_TEST_SUITE_P(
     CalculateLatency,
     InferenceManagerTest,


### PR DESCRIPTION
# Clamp a custom latency to the internal model latency

`SessionElement::prepare` primes the receive buffer with
`m_latency[i] − internal_model_latency[i]` zeros. The calculated latency always
has the internal latency added first, but a `custom_latency` replaces the whole
value — so a custom latency below the internal one makes that unsigned
subtraction wrap and the priming loop tries to push ~4 G samples per channel.

Now a custom value below `internal_model_latency` is clamped to it with a
`LOG_WARNING`; values at or above are kept as before.

Test: `InferenceManagerCustomLatency.ClampsToInternalModelLatency`
(internal = 100: custom 10 → 100, custom 500 → 500). Fails on `main`
(`10` vs `100`), passes with the fix.

Note for #66: whatever the float-latency rewrite does with the custom override,
it should keep `latency ≥ internal_model_latency` (or its float equivalent).
