### PR TITLE
cmake: retry transient download failures once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The backend-archive, release-metadata and RAVE-model downloads retry once after a transient failure (SSL connect errors against GitHub occasionally failed a CI configure).
+
 - The JUCE example links under clang on Linux (JUCE's recommended LTO flags produced undefined vtable references with clang + GNU ld and are dropped — an example gains nothing from LTO) and stages its Windows runtime DLLs generator-agnostically (the helper-tool and per-format paths assumed the Visual Studio generator's per-config layout; Ninja has none).
 
 - Backend runtime symbols are no longer exported from binaries embedding anira, which crashed hosts that ship their own runtime (Ableton Live 12 bundles ONNX Runtime): the engine archives are linked hidden, `libanira` exports exactly the `anira::` API (previously ~3800 `std::`/`c10::`/`executorch::`/`xnn_*` symbols leaked past `-fvisibility=hidden`), a static anira leaks nothing (`ANIRA_API` used to expand to `visibility("default")` on ELF/Mach-O even when static), and `OnnxRuntimeProcessor` throws a descriptive error instead of crashing when `OrtGetApiBase()` resolved to a foreign runtime. On macOS a plugin embedding a static anira with ExecuTorch must restrict its own exports (`-exported_symbols_list`; see the troubleshooting guide).

--- a/cmake/backends.cmake
+++ b/cmake/backends.cmake
@@ -100,6 +100,26 @@ endfunction()
 # configure and cache the path (empty if the check is disabled / unreachable /
 # CMake too old for string(JSON)). Honors $GITHUB_TOKEN to dodge API rate limits.
 # ------------------------------------------------------------------------------
+# _anira_download(<url> <out-file> <status-var> [extra file(DOWNLOAD) args...])
+# file(DOWNLOAD) with one retry after a short pause: transient TLS/connect
+# errors against GitHub happen often enough to fail a CI leg.
+function(_anira_download url dest out_status)
+    foreach(_attempt RANGE 1 2)
+        file(DOWNLOAD "${url}" "${dest}" STATUS _st ${ARGN})
+        list(GET _st 0 _code)
+        if(_code EQUAL 0)
+            break()
+        endif()
+        if(_attempt EQUAL 1)
+            list(GET _st 1 _msg)
+            message(STATUS "anira: download failed (${_msg}), retrying once: ${url}")
+            file(REMOVE "${dest}")
+            execute_process(COMMAND "${CMAKE_COMMAND}" -E sleep 3)
+        endif()
+    endforeach()
+    set(${out_status} "${_st}" PARENT_SCOPE)
+endfunction()
+
 function(_anira_release_json out)
     get_property(_done GLOBAL PROPERTY _ANIRA_RELEASE_JSON_DONE)
     if(_done)
@@ -120,9 +140,9 @@ function(_anira_release_json out)
     if(DEFINED ENV{GITHUB_TOKEN} AND NOT "$ENV{GITHUB_TOKEN}" STREQUAL "")
         list(APPEND _hdrs HTTPHEADER "Authorization: Bearer $ENV{GITHUB_TOKEN}")
     endif()
-    file(DOWNLOAD
+    _anira_download(
         "https://api.github.com/repos/anira-project/backends/releases/tags/${ANIRA_BACKENDS_VERSION}"
-        "${_json}" STATUS _st TIMEOUT 20 ${_hdrs})
+        "${_json}" _st TIMEOUT 20 ${_hdrs})
     list(GET _st 0 _code)
     if(NOT _code EQUAL 0)
         list(GET _st 1 _m)
@@ -280,7 +300,7 @@ function(_anira_download_extract url sha256 dest archive flatten)
         set(_hash_args EXPECTED_HASH "SHA256=${sha256}")
     endif()
 
-    file(DOWNLOAD "${url}" "${_zip}" STATUS _st SHOW_PROGRESS ${_hash_args})
+    _anira_download("${url}" "${_zip}" _st SHOW_PROGRESS ${_hash_args})
     list(GET _st 0 _code)
     list(GET _st 1 _msg)
 
@@ -351,7 +371,7 @@ function(_anira_acquire_backend url asset dest)
     if(NOT _digest STREQUAL "")
         set(_hash_args EXPECTED_HASH "SHA256=${_digest}")
     endif()
-    file(DOWNLOAD "${url}" "${_zip}" STATUS _st SHOW_PROGRESS ${_hash_args})
+    _anira_download("${url}" "${_zip}" _st SHOW_PROGRESS ${_hash_args})
     list(GET _st 0 _code)
     list(GET _st 1 _msg)
 

--- a/extras/fetch-models.cmake
+++ b/extras/fetch-models.cmake
@@ -103,15 +103,26 @@ if(ANIRA_MODELS_FETCH_RAVE)
         # Download to a partial name and rename on success, so an interrupted
         # download never leaves a truncated model the exists-check accepts.
         file(REMOVE "${_rave_dir}/rave_funk_drum.ts.part")
-        file(DOWNLOAD
-            "${_rave_url}"
-            "${_rave_dir}/rave_funk_drum.ts.part"
-            SHOW_PROGRESS
-            EXPECTED_HASH SHA256=${_anira_rave_sha256}
-            STATUS _rave_status
-            LOG _rave_log
-        )
-        list(GET _rave_status 0 _rave_result)
+        # One retry: transient TLS/connect errors against GitHub happen.
+        foreach(_attempt RANGE 1 2)
+            file(DOWNLOAD
+                "${_rave_url}"
+                "${_rave_dir}/rave_funk_drum.ts.part"
+                SHOW_PROGRESS
+                EXPECTED_HASH SHA256=${_anira_rave_sha256}
+                STATUS _rave_status
+                LOG _rave_log
+            )
+            list(GET _rave_status 0 _rave_result)
+            if(_rave_result EQUAL 0)
+                break()
+            endif()
+            if(_attempt EQUAL 1)
+                message(STATUS "RAVE download failed, retrying once")
+                file(REMOVE "${_rave_dir}/rave_funk_drum.ts.part")
+                execute_process(COMMAND "${CMAKE_COMMAND}" -E sleep 3)
+            endif()
+        endforeach()
         if(NOT _rave_result EQUAL 0)
             file(REMOVE "${_rave_dir}/rave_funk_drum.ts.part")
             message(FATAL_ERROR "Failed to download RAVE model: ${_rave_log}")


### PR DESCRIPTION
Backend archives, the release metadata and the RAVE model fetch through `_anira_download` (an inline loop in the standalone fetch-models script), which retries once after a 3 s pause — transient SSL connect errors against GitHub have failed CI configures repeatedly (latest: `Windows-x86_64-tflite-shared` on the 5a merge push, `SSL connect error` at `cmake/backends.cmake:354`).

Validated locally: a real tflite archive fetch through the helper (extract + stamp intact), and the retry path against an unreachable URL (one retry with a status message, then the failure status propagates to the caller's existing FATAL_ERROR/degrade handling).