### PR TITLE
context: never start tanh-lib's own log drain thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The first pre-release of the 3.x line: the configuration layer of the versioned 
 
 ### Fixed
 
+- The context no longer starts tanh-lib's own log drain thread: setting the logger's platform identity at core start went through `thl::Logger::set_config()`, whose default `m_rt_enabled` also starts tanh-lib's drain thread over its default real-time queue, which anira never uses and never stopped. Inside a plugin that thread outlived every session and kept the module mapped after the host's `FreeLibrary` (the `LibraryUnload` tests on the Windows static release legs). The core passes `m_rt_enabled = false`; `Logger.TheCoreNeverStartsTanhLibsOwnDrainThread` pins it.
 - `test/abi`: the consumer-shaped compile gates now really compile without the test model-path defines (a directory-level clear; the target-level clear never applied to a parent `add_compile_definitions`), and the "2.x umbrella first" coexistence order is actually compiled (clang-format had regrouped the includes so both drivers compiled the same order).
 - A failing inference now delivers zeros for that task on every engine, never the previous job's output (ONNX Runtime copied stale outputs after a caught exception; LiteRT and ExecuTorch left the buffer untouched; TFLite ignored the status).
 - LibTorch: a `c10::Error` thrown by `forward` on the inference thread escaped the instance and left it marked busy forever (the pool loop then spun on the remaining instances). The inference now catches per task and the busy flag is released on every exit path.

--- a/src/scheduler/Context.cpp
+++ b/src/scheduler/Context.cpp
@@ -268,6 +268,14 @@ void Context::start_log_drain_locked(Core& c, const ContextConfig& context_confi
             logger_config.m_platform_tag = "anira";
             logger_config.m_platform_subsystem = "anira";
             logger_config.m_platform_category = "anira";
+            // set_config() also starts tanh-lib's own drain thread over its default
+            // real-time queue when m_rt_enabled is set, and the default config has it
+            // set. anira never uses that queue: the core owns its records (c.m_log_queue)
+            // and drains them itself (c.m_log_drain, or the host under LogDrain::Manual).
+            // A thread the core does not own would outlive every session, and inside a
+            // plugin it would still be alive when the host unloads the module (the
+            // LibraryUnload tests on the Windows static legs: the module stays mapped).
+            logger_config.m_rt_enabled = false;
             thl::Logger::set_config(logger_config);
         }
         // Once per core: the queue is what the real-time sites hold a pointer to, so it

--- a/test/utils/test_Logger.cpp
+++ b/test/utils/test_Logger.cpp
@@ -108,6 +108,21 @@ TEST(Logger, RtQueueExistsExactlyWhileTheCoreDoes) {
     }
 }
 
+TEST(Logger, TheCoreNeverStartsTanhLibsOwnDrainThread) {
+    // The core sets the logger's platform identity through set_config(), which would
+    // also start tanh-lib's drain thread over its default real-time queue if the config
+    // asked for it. anira drains its own queue (LogDrain::Thread or Manual); a thread
+    // the core does not own would survive every session and, inside a plugin, the
+    // host's unload of the module (LibraryUnload on the Windows static legs).
+    {
+        const Instance instance{make_context_config(LogDrain::Thread)};
+        EXPECT_FALSE(thl::Logger::rt::is_running())
+            << "tanh-lib's default drain thread runs while a session exists";
+    }
+    EXPECT_FALSE(thl::Logger::rt::is_running())
+        << "tanh-lib's default drain thread survived the last session";
+}
+
 #ifndef __EMSCRIPTEN__
 TEST(Logger, ThreadDrainDeliversRtRecordsWhileASessionExists) {
     RecordCollector collector;


### PR DESCRIPTION
Fix for the three `LibraryUnload` failures on the Windows static legs of the `v3.0.0-alpha.1` release run (`Windows-x86_64-static`, `Windows-x86_64-tflite-static`, `Windows-arm64-static`; every other leg passed). Against `v3`; the alpha.1 tag moves onto the merge.

## Cause

Since PR #167 the core sets the logger's platform identity at start through `thl::Logger::set_config()`. tanh-lib 0.3.0's `set_config()` ends with `start_drain_thread(true)` when `m_rt_enabled` is set, and `LoggerConfig::m_rt_enabled` defaults to `true`, so the call also started tanh-lib's own drain thread over its default real-time queue. anira never uses that queue (the core owns its records in `c.m_log_queue` and drains them itself), never stopped that thread, and it outlived every session. Inside the plugin-shaped test module that thread was still alive at `FreeLibrary`, and the module stayed mapped: `is_mapped(k_module_path)` true in `DefaultPolicyLeavesNoThreadBehind`, `UnloadWithLiveSessionIsJoinedByHook` and `ReloadAfterUnloadWorks`. The shared Windows leg passed because there tanh-lib lives in `anira.dll`, and the v2.3.0 release passed because 2.3.0 never called `set_config()`.

## Fix

`Context::start_log_drain_locked` passes `m_rt_enabled = false` with the identity, which is the state 2.3.0 ran in (tanh-lib's thread "never started implicitly"). `Logger.TheCoreNeverStartsTanhLibsOwnDrainThread` asserts `thl::Logger::rt::is_running()` is false while a session exists and after the last one goes; it fails at both assertions without the fix, on every platform, so the PR tier catches a regression even though it has no Windows static leg.

## Verification

- local (full-engine Debug tree): the nine `Logger.*` tests pass with the fix; the new test fails without it (checked by flipping the flag and rebuilding)
- the Windows static leg itself is being exercised on the scratch branch `scratch/win-static-unload` (workflow `scratch_unload_windows`: the tree before and after this commit, `ctest -R 'LibraryUnload|Logger\.'`); the branch is deleted once it has answered
- CHANGELOG: `### Fixed` of `[v3.0.0-alpha.1]`, since the tag moves onto this fix