### PR TITLE
rings: one RingBufferT<T> per slot behind the 2.x float face

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Every input and output ring of the pipeline is an instantiation of `RingBufferT<T>` with `T` the element type of the slot's ring dtype: `anira_ring` (`anira/utils/RingBuffer.h`, the type `anira::RingBuffer` now names) holds one of the nine scalar dtypes the rings store (float32, float16, bfloat16, int8, uint8, bool8, int16, int32, int64; float32 unless a slot says otherwise) behind a dtype tag, chosen at prepare: `SessionElement::prepare` and `Context::prepare_session` take the per-slot `RingDtypes`, which the 2.x `InferenceManager::prepare` leaves at float32 for every slot (a new overload carries them for the 3.x prepare). The ring's block API (`push_block`, `pop_block`, `peek_past_block`, `push_fill`, `push_zeros`, `discard`, `pop_windows`, which now holds the batched sliding-window pop of `PrePostProcessor::pop_samples_from_buffer`) takes the caller's dtype, returns 0 and writes nothing on a disagreement, and never converts; the 2.x float API stays as the float32 face, so every 2.x pre/post processor compiles unchanged. Storage only: the typed Hard entries that reach the rings follow with the 3.x handler.
+
 ## [v3.0.0-alpha.1] - 2026-09-03
 
 The first pre-release of the 3.x line: the configuration layer of the versioned C ABI (`anira/abi/*.h`, ABI 0.1) with its JSON loaders, the C++20 builders of `anira/anira.hpp`, and a transitional bridge to the unchanged 2.x runtime. Nothing in it is a binary promise before v3.0.0: while the ABI major is 0 a library accepts only the exact ABI version its headers were generated with, and every pre-release may still change any of it. The soname stays 3 until the 3.x handler lands and flips it to the ABI major. The npm package is still the 2.x TypeScript API, published under the `next` tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ABI (unstable):** `ANIRA_DTYPE_F64`, the 64-bit float dtype (`ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 64, 1)`), beside the nine scalar dtypes the headers already pinned; `"float64"` in the JSON dtype vocabulary and `web/src/abi/enums.ts`.
+
 ### Changed
 
-- Every input and output ring of the pipeline is an instantiation of `RingBufferT<T>` with `T` the element type of the slot's ring dtype: `anira_ring` (`anira/utils/RingBuffer.h`, the type `anira::RingBuffer` now names) holds one of the nine scalar dtypes the rings store (float32, float16, bfloat16, int8, uint8, bool8, int16, int32, int64; float32 unless a slot says otherwise) behind a dtype tag, chosen at prepare: `SessionElement::prepare` and `Context::prepare_session` take the per-slot `RingDtypes`, which the 2.x `InferenceManager::prepare` leaves at float32 for every slot (a new overload carries them for the 3.x prepare). The ring's block API (`push_block`, `pop_block`, `peek_past_block`, `push_fill`, `push_zeros`, `discard`, `pop_windows`, which now holds the batched sliding-window pop of `PrePostProcessor::pop_samples_from_buffer`) takes the caller's dtype, returns 0 and writes nothing on a disagreement, and never converts; the 2.x float API stays as the float32 face, so every 2.x pre/post processor compiles unchanged. Storage only: the typed Hard entries that reach the rings follow with the 3.x handler.
+- Every input and output ring of the pipeline is an instantiation of `RingBufferT<T>` with `T` the element type of the slot's ring dtype: `anira_ring` (`anira/utils/RingBuffer.h`, the type `anira::RingBuffer` now names) holds one instantiation per scalar dtype the ABI pins (float32, float64, float16, bfloat16, int8, uint8, bool8, int16, int32, int64, with `T` the dtype's C type and the three that have none stored as their bits; no two dtypes share a ring; float32 unless a slot says otherwise), chosen at prepare: `SessionElement::prepare` and `Context::prepare_session` take the per-slot `RingDtypes` and the caller's `CustomLatencies` (the former `std::vector<long>`, named), which the 2.x `InferenceManager::prepare` fills from its arguments (a new overload carries both for the 3.x prepare). The ring's block API (`push_block`, `pop_block`, `peek_past_block`, `push_fill`, `push_zeros`, `discard`, `pop_windows`, which now holds the batched sliding-window pop of `PrePostProcessor::pop_samples_from_buffer`) takes the caller's dtype, returns 0 and writes nothing on a disagreement, and never converts; the 2.x float API stays as the float32 face, so every 2.x pre/post processor compiles unchanged. Storage only: the typed Hard entries that reach the rings follow with the 3.x handler.
 
 ## [v3.0.0-alpha.1] - 2026-09-03
 

--- a/abi/anira.json
+++ b/abi/anira.json
@@ -529,6 +529,13 @@
         },
         {
           "kind": "define",
+          "name": "ANIRA_DTYPE_F64",
+          "value": "ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 64, 1)",
+          "ts": "0x00014002",
+          "doc": "64-bit float, one lane."
+        },
+        {
+          "kind": "define",
           "name": "ANIRA_DTYPE_F16",
           "value": "ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 16, 1)",
           "ts": "0x00011002",

--- a/abi/anira.yml
+++ b/abi/anira.yml
@@ -325,6 +325,7 @@ headers:
         ts: "(d: number): number => d >>> 16"
         doc: "The lane count of a packed dtype."
       - {kind: define, name: ANIRA_DTYPE_F32, value: "ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 32, 1)", ts: "0x00012002", doc: "32-bit float, one lane: the type of every v2 stream and the only one the Hard entries carry."}
+      - {kind: define, name: ANIRA_DTYPE_F64, value: "ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 64, 1)", ts: "0x00014002", doc: "64-bit float, one lane."}
       - {kind: define, name: ANIRA_DTYPE_F16, value: "ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 16, 1)", ts: "0x00011002", doc: "16-bit float."}
       - {kind: define, name: ANIRA_DTYPE_BF16, value: "ANIRA_MAKE_DTYPE(ANIRA_DTYPE_BFLOAT, 16, 1)", ts: "0x00011004", doc: "bfloat16."}
       - {kind: define, name: ANIRA_DTYPE_I8, value: "ANIRA_MAKE_DTYPE(ANIRA_DTYPE_INT, 8, 1)", ts: "0x00010800", doc: "Signed 8-bit integer."}

--- a/docs/anira-v3-architecture.md
+++ b/docs/anira-v3-architecture.md
@@ -41,7 +41,7 @@ typedef uint32_t anira_dtype;                              /* code | bits << 8 |
 #define ANIRA_DTYPE_CODE(d)  ((d) & 0xffu)
 #define ANIRA_DTYPE_BITS(d)  (((d) >> 8) & 0xffu)
 #define ANIRA_DTYPE_LANES(d) ((d) >> 16)
-#define ANIRA_DTYPE_F32 ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 32, 1)   /* also F16, BF16, I8, U8, I16, I32, I64, BOOL8 */
+#define ANIRA_DTYPE_F32 ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 32, 1)   /* also F64, F16, BF16, I8, U8, I16, I32, I64, BOOL8 */
 #define ANIRA_MAX_RANK 8
 
 /* abi/tensor.h -- Tier-1 PODs, frozen at M2. ANIRA_API / ANIRA_CALL elided; NB = ANIRA_NONBLOCKING;

--- a/docs/sphinx/contributing.rst
+++ b/docs/sphinx/contributing.rst
@@ -200,9 +200,11 @@ build. Select a component with ``ctest -L test_scheduler`` (the label is the
 binary name).
 
 Do not re-test what tanh-lib already covers upstream: ``anira::Buffer``,
-``RingBuffer``, ``MemoryBlock`` and the threading primitives are thin aliases over
-``thl::core``, which has its own suite. anira keeps only tests of its own contract on
-top of them; coverage that belongs to the underlying container goes to tanh-lib.
+``MemoryBlock`` and the threading primitives are thin aliases over ``thl::core``, which
+has its own suite, and ``anira::RingBuffer`` (``anira_ring``) holds one
+``thl::core::RingBuffer<T>`` per ring dtype. anira keeps only tests of its own contract on
+top of them (the ring's dtype tag, its refusals and its window pop; not the storage);
+coverage that belongs to the underlying container goes to tanh-lib.
 
 Sanitizers
 ~~~~~~~~~~

--- a/docs/sphinx/custom_preprocessing.rst
+++ b/docs/sphinx/custom_preprocessing.rst
@@ -21,6 +21,9 @@ Anira supports two types of tensors that require different handling in custom pr
 - Have ``preprocess_input_size > 0`` and ``postprocess_output_size > 0``
 - Data comes from :cpp:class:`anira::RingBuffer` instances via the ``input`` parameter
 - Use helper methods like ``pop_samples_from_buffer()`` to extract data
+- Every ring stores the element type of its slot's ring dtype (float32 unless the contract
+  declares another one, see the usage guide's contract section); the float helpers and the
+  float ring calls are the float32 face and do nothing on a ring of another type
 
 **Non-Streamable Tensors:**
 - Control parameters, static values, or metadata (non-time-varying)

--- a/include/anira/abi/enums.h
+++ b/include/anira/abi/enums.h
@@ -81,6 +81,11 @@ typedef enum anira_dtype_code {
 #define ANIRA_DTYPE_F32 ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 32, 1)
 
 /**
+ * @brief 64-bit float, one lane.
+ */
+#define ANIRA_DTYPE_F64 ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 64, 1)
+
+/**
  * @brief 16-bit float.
  */
 #define ANIRA_DTYPE_F16 ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 16, 1)

--- a/include/anira/scheduler/Context.h
+++ b/include/anira/scheduler/Context.h
@@ -242,6 +242,8 @@ public:
      * @param session Shared pointer to the session to prepare
      * @param new_config New host configuration with audio settings
      * @param custom_latency Optional vector of custom latency values for each tensor
+     * @param ring_dtypes The element type of every send and receive ring, per slot (see
+     * RingDtypes; float32 for every slot not named, which is what the 2.x path passes)
      *
      * @note Thread-safe with respect to other sessions' lifecycle calls. Not
      *       safe against concurrent processing calls on the *same* session —
@@ -249,7 +251,8 @@ public:
      */
     void prepare_session(const std::shared_ptr<SessionElement>& session,
                          HostConfig new_config,
-                         std::vector<long> custom_latency = {});
+                         std::vector<long> custom_latency = {},
+                         const RingDtypes& ring_dtypes = {});
 
     /**
      * @brief Gets the number of registered inference sessions

--- a/include/anira/scheduler/Context.h
+++ b/include/anira/scheduler/Context.h
@@ -241,7 +241,8 @@ public:
      *
      * @param session Shared pointer to the session to prepare
      * @param new_config New host configuration with audio settings
-     * @param custom_latency Optional vector of custom latency values for each tensor
+     * @param custom_latencies A caller's latency per output tensor (see CustomLatencies;
+     * empty keeps every computed latency)
      * @param ring_dtypes The element type of every send and receive ring, per slot (see
      * RingDtypes; float32 for every slot not named, which is what the 2.x path passes)
      *
@@ -251,7 +252,7 @@ public:
      */
     void prepare_session(const std::shared_ptr<SessionElement>& session,
                          HostConfig new_config,
-                         std::vector<long> custom_latency = {},
+                         const CustomLatencies& custom_latencies = {},
                          const RingDtypes& ring_dtypes = {});
 
     /**

--- a/include/anira/scheduler/InferenceManager.h
+++ b/include/anira/scheduler/InferenceManager.h
@@ -86,15 +86,16 @@ public:
 
     /**
      * @brief The prepare of the 3.x path: like prepare(HostConfig, std::vector<long>), with
-     * the element type of every send and receive ring named per slot.
+     * the caller's latencies and the element type of every send and receive ring named per
+     * slot.
      *
      * @param config Host configuration containing sample rate, buffer size, and audio settings
-     * @param custom_latency Optional vector of custom latency values for each tensor
+     * @param custom_latencies A caller's latency per output tensor (see CustomLatencies)
      * @param ring_dtypes The ring dtype of every slot (see RingDtypes); the two-argument
      * overload passes float32 for every slot
      */
     void prepare(HostConfig config,
-                 std::vector<long> custom_latency,
+                 const CustomLatencies& custom_latencies,
                  const RingDtypes& ring_dtypes);
 
     /**

--- a/include/anira/scheduler/InferenceManager.h
+++ b/include/anira/scheduler/InferenceManager.h
@@ -85,6 +85,19 @@ public:
     void prepare(HostConfig config, std::vector<long> custom_latency = {});
 
     /**
+     * @brief The prepare of the 3.x path: like prepare(HostConfig, std::vector<long>), with
+     * the element type of every send and receive ring named per slot.
+     *
+     * @param config Host configuration containing sample rate, buffer size, and audio settings
+     * @param custom_latency Optional vector of custom latency values for each tensor
+     * @param ring_dtypes The ring dtype of every slot (see RingDtypes); the two-argument
+     * overload passes float32 for every slot
+     */
+    void prepare(HostConfig config,
+                 std::vector<long> custom_latency,
+                 const RingDtypes& ring_dtypes);
+
+    /**
      * @brief Processes multi-tensor audio data with separate input and output buffers
      *
      * Performs complete inference processing for multiple tensors simultaneously,

--- a/include/anira/scheduler/SessionElement.h
+++ b/include/anira/scheduler/SessionElement.h
@@ -69,6 +69,19 @@ class ExecuTorchProcessor;
  * @note Each session has a unique ID and maintains its own processing state
  *       while participating in the global inference scheduling system.
  */
+/**
+ * @brief The element type of every send and receive ring of a session, per slot.
+ *
+ * What the driver pushes into an input ring and pops out of an output ring: the ring dtype the
+ * host declared for the slot on the Hard contract (`anira_contract_hard_set_ring_dtype`). A slot
+ * beyond the end of a vector, or an empty vector, is float32, the 2.x default and what the 2.x
+ * InferenceManager::prepare() passes for every slot.
+ */
+struct RingDtypes {
+    std::vector<anira_dtype> m_inputs;   ///< Per input tensor: the send ring's element type
+    std::vector<anira_dtype> m_outputs;  ///< Per output tensor: the receive ring's element type
+};
+
 class ANIRA_API SessionElement {
 public:
     /**
@@ -124,10 +137,16 @@ public:
      * @param custom_latency Optional vector of custom latency values for each tensor (empty for
      * automatic calculation); entries for non-streamable outputs are ignored, their latency is
      * always 0
+     * @param ring_dtypes The element type of every send and receive ring, per slot (float32
+     * for every slot the vectors do not name); the ring sizes are element counts, so they do not
+     * depend on it
      * @throws std::invalid_argument if the host config's reference stream cannot be resolved
-     *         (explicit reference out of range or not streamable, or no streamable tensor at all)
+     *         (explicit reference out of range or not streamable, or no streamable tensor at all),
+     *         or if a ring dtype is not one of the scalar dtypes the rings store
      */
-    void prepare(const HostConfig& spec, std::vector<long> custom_latency = {});
+    void prepare(const HostConfig& spec,
+                 std::vector<long> custom_latency = {},
+                 const RingDtypes& ring_dtypes = {});
 
     /**
      * @brief Template method for setting backend processors

--- a/include/anira/scheduler/SessionElement.h
+++ b/include/anira/scheduler/SessionElement.h
@@ -82,6 +82,20 @@ struct RingDtypes {
     std::vector<anira_dtype> m_outputs;  ///< Per output tensor: the receive ring's element type
 };
 
+/**
+ * @brief A caller's latency per output tensor, replacing the computed one.
+ *
+ * One entry per output tensor, in samples of that output's stream: a value of 0 or more
+ * replaces the latency LatencyCalculator computed for that output (clamped up to the model's
+ * internal latency, which the receive ring must still cover), a negative value keeps the
+ * computed one. An empty vector, or one whose length is not the number of output tensors,
+ * keeps every computed latency. A non-streamable output has no stream latency whatever its
+ * entry says.
+ */
+struct CustomLatencies {
+    std::vector<long> m_outputs;  ///< Per output tensor: the latency in samples, or negative
+};
+
 class ANIRA_API SessionElement {
 public:
     /**
@@ -134,18 +148,18 @@ public:
      * real-time path.
      *
      * @param spec Host configuration containing sample rate, buffer size, and audio settings
-     * @param custom_latency Optional vector of custom latency values for each tensor (empty for
-     * automatic calculation); entries for non-streamable outputs are ignored, their latency is
-     * always 0
-     * @param ring_dtypes The element type of every send and receive ring, per slot (float32
-     * for every slot the vectors do not name); the ring sizes are element counts, so they do not
-     * depend on it
+     * @param custom_latencies A caller's latency per output tensor (see CustomLatencies; empty
+     * keeps every computed latency); entries for non-streamable outputs are ignored, their
+     * latency is always 0
+     * @param ring_dtypes The element type of every send and receive ring, per slot (see
+     * RingDtypes; float32 for every slot the vectors do not name); the ring sizes are element
+     * counts, so they do not depend on it
      * @throws std::invalid_argument if the host config's reference stream cannot be resolved
      *         (explicit reference out of range or not streamable, or no streamable tensor at all),
      *         or if a ring dtype is not one of the scalar dtypes the rings store
      */
     void prepare(const HostConfig& spec,
-                 std::vector<long> custom_latency = {},
+                 const CustomLatencies& custom_latencies = {},
                  const RingDtypes& ring_dtypes = {});
 
     /**

--- a/include/anira/utils/RingBuffer.h
+++ b/include/anira/utils/RingBuffer.h
@@ -1,44 +1,341 @@
 #ifndef ANIRA_RINGBUFFER_H
 #define ANIRA_RINGBUFFER_H
 
+#include <anira/abi/enums.h>
 #include <tanh/core/RingBuffer.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+#include <utility>
+#include <variant>
 
 #include "Buffer.h"
 
-namespace anira {
+// NOLINTBEGIN(readability-identifier-naming)
+// The C tag: anira_ring is the type the 3.x ring accessors take (abi/stage.h), so it lives
+// outside namespace anira like the other handle types; its members follow anira's C++ names.
 
 /**
- * @brief Multi-channel ring buffer for streaming data
+ * @brief The ring of one streamed slot, holding the element type of that slot's ring dtype.
  *
- * Provided by tanh-lib's Apache-2.0 core component (thl::core). Semantics:
- *  - push_sample() into a full channel silently overwrites the oldest sample
- *    (the read position advances); pop_sample() on an empty channel yields
- *    a value-initialised element (0 for arithmetic types). Neither logs.
- *  - get_future_sample(ch, n) reads the n-th unread sample without popping;
- *    get_past_sample(ch, n) reads the n-th sample behind the read position
- *    (history). Offsets are wrapped modulo the capacity and are not range
- *    checked against the available/consumed counts: reading further than
- *    that returns whatever the slot holds (0 after clear/initialise).
- *  - get_available_samples() is the unread count; get_available_past_samples()
- *    is the number of consumed samples still retained as history (0 right
- *    after initialise/clear, growing as samples are popped).
- *  - Unlike anira's former in-tree ring buffer this class does not derive
- *    from Buffer: there is no direct pointer/sample access to the storage.
+ * Every input and output ring of the inference pipeline is one instantiation of
+ * thl::core::RingBuffer<T> (anira::RingBufferT<T>), with T the element type of the ring dtype
+ * the host declared for the slot on the Hard contract (`anira_contract_hard_set_ring_dtype`;
+ * float32 when nothing was declared). This holder owns that instantiation behind a dtype tag,
+ * so a std::vector of rings can mix element types, and dispatches every block operation to it.
  *
- * Push
- * semantics are delay-line friendly: pushing into a full channel overwrites
- * the oldest sample; popping an empty channel returns a value-initialized
- * element.
+ * The rings never convert: what the driver pushes into an input ring is what the pre-processor
+ * pops out of it, and what the post-processor pushes into an output ring is what the driver pops
+ * out of it, byte for byte (section 7 of the architecture document). The block API therefore
+ * takes the caller's dtype beside the data and refuses, returning 0 with nothing written, when
+ * it is not the ring's own. The two 16-bit floating-point dtypes are stored as their uint16_t bit
+ * patterns: no arithmetic happens on a ring element.
  *
- * anira::RingBuffer remains the float instantiation used throughout the
- * inference pipeline; RingBufferT gives access to other element types
- * (e.g. integer token streams).
+ * The nine scalar dtypes the rings store are float32, float16, bfloat16, int8, uint8, bool8,
+ * int16, int32 and int64; a dtype with more than one lane, an opaque dtype or float64 is refused
+ * at initialize_with_positions(), which is what the 3.x prepare reports as a configuration
+ * error.
  *
- * @see Buffer, PrePostProcessor
+ * Semantics of the storage (tanh-lib's Apache-2.0 core component, thl::core::RingBuffer):
+ *  - push_sample() into a full channel silently overwrites the oldest sample (the read
+ *    position advances); pop_sample() on an empty channel yields a value-initialised element
+ *    (0 for arithmetic types). Neither logs.
+ *  - get_future_sample(ch, n) reads the n-th unread sample without popping; get_past_sample(ch,
+ *    n) reads the n-th sample behind the read position (history). Offsets are wrapped modulo the
+ *    capacity and are not range checked against the available/consumed counts: reading further
+ *    than that returns whatever the slot holds (0 after clear/initialise).
+ *  - available() (get_available_samples()) is the unread count; available_past()
+ *    (get_available_past_samples()) is the number of consumed samples still retained as history
+ *    (0 right after initialise/clear, growing as samples are popped).
+ *  - The ring does not derive from Buffer: there is no direct pointer/sample access to the
+ *    storage.
+ *
+ * The float API (push_sample, pop_sample, the float block calls, get_future_sample,
+ * get_past_sample, the two-argument initialize_with_positions) is the face the 2.x classes
+ * and their pre/post processors were written against; it is the float32 arm of this type. On a
+ * ring of another dtype it does nothing and returns 0: the 3.x entries check the ring dtype
+ * before they reach it. anira::RingBuffer names this type for the 2.x classes of this
+ * pre-release and leaves with them.
+ *
+ * @see anira::RingBufferT, Buffer, PrePostProcessor
  */
-using RingBuffer = thl::core::RingBuffer<float>;
+struct anira_ring {
+public:
+    anira_ring() = default;
 
-/// Generic-element ring buffer.
+    /// The 2.x face: a float32 ring of `num_channels` channels and `num_samples` elements each.
+    void initialize_with_positions(size_t num_channels, size_t num_samples) {
+        (void)initialize_with_positions(num_channels, num_samples, ANIRA_DTYPE_F32);
+    }
+
+    /**
+     * @brief Makes this a ring of `dtype`, `num_channels` channels and `num_samples` elements
+     * each, cleared.
+     *
+     * @return true; false, with the ring left as it was, when `dtype` is not one of the nine
+     * scalar dtypes the rings store (a dtype with more than one lane, an opaque dtype, float64).
+     */
+    bool initialize_with_positions(size_t num_channels, size_t num_samples, anira_dtype dtype) {
+        size_t index = 0;
+        if (!arm_index_of(dtype, index)) { return false; }
+        if (m_storage.index() != index) { emplace_arm(index); }
+        m_dtype = dtype;
+        std::visit([&](auto& ring) { ring.initialize_with_positions(num_channels, num_samples); },
+                   m_storage);
+        return true;
+    }
+
+    /// Empties every channel and resets its positions; the dtype and the capacity stay.
+    void clear_with_positions() {
+        std::visit([](auto& ring) { ring.clear_with_positions(); }, m_storage);
+    }
+
+    /// The element type this ring stores (float32 for a ring that was never initialised).
+    [[nodiscard]] anira_dtype dtype() const noexcept { return m_dtype; }
+
+    [[nodiscard]] size_t num_channels() const {
+        return std::visit([](const auto& ring) { return ring.get_num_channels(); }, m_storage);
+    }
+
+    /// Elements per channel.
+    [[nodiscard]] size_t capacity() const {
+        return std::visit([](const auto& ring) { return ring.get_num_samples(); }, m_storage);
+    }
+
+    /// Unread elements of `channel`.
+    [[nodiscard]] size_t available(size_t channel) const {
+        return std::visit(
+            [channel](const auto& ring) { return ring.get_available_samples(channel); },
+            m_storage);
+    }
+
+    /// Consumed elements of `channel` still retained as history.
+    [[nodiscard]] size_t available_past(size_t channel) const {
+        return std::visit(
+            [channel](const auto& ring) { return ring.get_available_past_samples(channel); },
+            m_storage);
+    }
+
+    // ---- The block API: dtype-checked, never converting. Every call returns the number of
+    // elements it moved, and 0 with nothing written when `dtype` is not the ring's own. -------
+
+    /// Pushes `count` elements of `dtype` from `data` into `channel` (the oldest are overwritten
+    /// when the ring is full).
+    size_t push_block(size_t channel, const void* data, anira_dtype dtype, size_t count) {
+        if (dtype != m_dtype) { return 0; }
+        std::visit(
+            [&](auto& ring) {
+                using T = element_t<decltype(ring)>;
+                ring.push_block(channel, static_cast<const T*>(data), count);
+            },
+            m_storage);
+        return count;
+    }
+
+    /// Pops `count` elements of `dtype` from `channel` into `data`; the elements beyond the
+    /// available ones are value-initialised.
+    size_t pop_block(size_t channel, void* data, anira_dtype dtype, size_t count) {
+        if (dtype != m_dtype) { return 0; }
+        std::visit(
+            [&](auto& ring) {
+                using T = element_t<decltype(ring)>;
+                ring.pop_block(channel, static_cast<T*>(data), count);
+            },
+            m_storage);
+        return count;
+    }
+
+    /// Copies the `count` most recently consumed elements of `channel` (history) into `data`,
+    /// oldest first, without popping.
+    size_t peek_past_block(size_t channel, void* data, anira_dtype dtype, size_t count) const {
+        if (dtype != m_dtype) { return 0; }
+        std::visit(
+            [&](const auto& ring) {
+                using T = element_t<decltype(ring)>;
+                ring.peek_past_block(channel, static_cast<T*>(data), count);
+            },
+            m_storage);
+        return count;
+    }
+
+    /// Pushes `count` copies of the element of `dtype` at `value` into `channel`.
+    size_t push_fill(size_t channel, const void* value, anira_dtype dtype, size_t count) {
+        if (dtype != m_dtype) { return 0; }
+        std::visit(
+            [&](auto& ring) {
+                using T = element_t<decltype(ring)>;
+                T element{};
+                std::memcpy(&element, value, sizeof(T));
+                ring.push_fill(channel, element, count);
+            },
+            m_storage);
+        return count;
+    }
+
+    /// Pushes `count` value-initialised elements into `channel`: the latency priming, whatever
+    /// the ring's dtype.
+    size_t push_zeros(size_t channel, size_t count) {
+        std::visit(
+            [&](auto& ring) {
+                using T = element_t<decltype(ring)>;
+                ring.push_fill(channel, T{}, count);
+            },
+            m_storage);
+        return count;
+    }
+
+    /// Drops up to `count` unread elements of `channel`; returns how many were dropped.
+    size_t discard(size_t channel, size_t count) {
+        return std::visit([&](auto& ring) { return ring.discard(channel, count); }, m_storage);
+    }
+
+    /**
+     * @brief Pops `num_batches` overlapping windows of `channel` into `data`.
+     *
+     * Window `b` lands at `data + offset + b * (num_new + num_old)` (in elements) and holds
+     * the `num_old` most recently consumed elements followed by `num_new` freshly popped
+     * ones: the batched sliding-window layout a model with an input shape
+     * `[num_batches, ..., num_new + num_old]` expects. Returns the elements written,
+     * `num_batches * (num_new + num_old)`.
+     */
+    size_t pop_windows(size_t channel,
+                       void* data,
+                       anira_dtype dtype,
+                       size_t num_new,
+                       size_t num_old,
+                       size_t offset,
+                       size_t num_batches) {
+        if (dtype != m_dtype) { return 0; }
+        const size_t window = num_new + num_old;
+        std::visit(
+            [&](auto& ring) {
+                using T = element_t<decltype(ring)>;
+                T* out = static_cast<T*>(data) + offset;
+                for (size_t batch = 0; batch < num_batches; ++batch) {
+                    T* const target = out + (batch * window);
+                    // The history precedes the read position, so it is read before pop_block()
+                    // advances it.
+                    ring.peek_past_block(channel, target, num_old);
+                    ring.pop_block(channel, target + num_old, num_new);
+                }
+            },
+            m_storage);
+        return num_batches * window;
+    }
+
+    // ---- The 2.x float face: the float32 arm. On a ring of another dtype these do nothing
+    // and return 0 (the 3.x entries check the dtype before they get here). ------------------
+
+    void push_sample(size_t channel, float sample) {
+        if (auto* ring = f32()) { ring->push_sample(channel, sample); }
+    }
+
+    float pop_sample(size_t channel) {
+        auto* ring = f32();
+        return ring != nullptr ? ring->pop_sample(channel) : 0.0F;
+    }
+
+    void push_block(size_t channel, const float* data, size_t count) {
+        if (auto* ring = f32()) { ring->push_block(channel, data, count); }
+    }
+
+    void pop_block(size_t channel, float* data, size_t count) {
+        if (auto* ring = f32()) { ring->pop_block(channel, data, count); }
+    }
+
+    void peek_past_block(size_t channel, float* data, size_t count) const {
+        if (const auto* ring = f32()) { ring->peek_past_block(channel, data, count); }
+    }
+
+    void push_fill(size_t channel, float value, size_t count) {
+        if (auto* ring = f32()) { ring->push_fill(channel, value, count); }
+    }
+
+    [[nodiscard]] float get_future_sample(size_t channel, size_t offset) const {
+        const auto* ring = f32();
+        return ring != nullptr ? ring->get_future_sample(channel, offset) : 0.0F;
+    }
+
+    [[nodiscard]] float get_past_sample(size_t channel, size_t offset) const {
+        const auto* ring = f32();
+        return ring != nullptr ? ring->get_past_sample(channel, offset) : 0.0F;
+    }
+
+    [[nodiscard]] size_t get_available_samples(size_t channel) const { return available(channel); }
+    [[nodiscard]] size_t get_available_past_samples(size_t channel) const {
+        return available_past(channel);
+    }
+    [[nodiscard]] size_t get_num_channels() const { return num_channels(); }
+    [[nodiscard]] size_t get_num_samples() const { return capacity(); }
+
+private:
+    // One arm per stored element type; the two 16-bit floats and the two 8-bit unsigned
+    // dtypes share a carrier, told apart by m_dtype.
+    using Storage = std::variant<thl::core::RingBuffer<float>,
+                                 thl::core::RingBuffer<int16_t>,
+                                 thl::core::RingBuffer<int32_t>,
+                                 thl::core::RingBuffer<int8_t>,
+                                 thl::core::RingBuffer<uint8_t>,
+                                 thl::core::RingBuffer<int64_t>,
+                                 thl::core::RingBuffer<uint16_t>>;
+
+    template <typename Ring>
+    struct element_of;
+    template <typename T>
+    struct element_of<thl::core::RingBuffer<T>> {
+        using type = T;
+    };
+    template <typename Ring>
+    using element_t = typename element_of<std::remove_cvref_t<Ring>>::type;
+
+    static bool arm_index_of(anira_dtype dtype, size_t& index) noexcept {
+        switch (static_cast<uint32_t>(dtype)) {
+            case ANIRA_DTYPE_F32: index = 0; return true;
+            case ANIRA_DTYPE_I16: index = 1; return true;
+            case ANIRA_DTYPE_I32: index = 2; return true;
+            case ANIRA_DTYPE_I8: index = 3; return true;
+            case ANIRA_DTYPE_U8:
+            case ANIRA_DTYPE_BOOL8: index = 4; return true;
+            case ANIRA_DTYPE_I64: index = 5; return true;
+            case ANIRA_DTYPE_F16:
+            case ANIRA_DTYPE_BF16: index = 6; return true;
+            default: return false;
+        }
+    }
+
+    void emplace_arm(size_t index) {
+        switch (index) {
+            case 0: m_storage.emplace<0>(); break;
+            case 1: m_storage.emplace<1>(); break;
+            case 2: m_storage.emplace<2>(); break;
+            case 3: m_storage.emplace<3>(); break;
+            case 4: m_storage.emplace<4>(); break;
+            case 5: m_storage.emplace<5>(); break;
+            default: m_storage.emplace<6>(); break;
+        }
+    }
+
+    thl::core::RingBuffer<float>* f32() noexcept {
+        return m_dtype == ANIRA_DTYPE_F32 ? std::get_if<0>(&m_storage) : nullptr;
+    }
+    const thl::core::RingBuffer<float>* f32() const noexcept {
+        return m_dtype == ANIRA_DTYPE_F32 ? std::get_if<0>(&m_storage) : nullptr;
+    }
+
+    anira_dtype m_dtype = ANIRA_DTYPE_F32;
+    Storage m_storage;  ///< Default-constructed: the float32 arm, no capacity
+};
+// NOLINTEND(readability-identifier-naming)
+
+namespace anira {
+
+/// The ring of one streamed slot (see anira_ring): the 2.x classes' ring type in this
+/// pre-release.
+using RingBuffer = anira_ring;
+
+/// Generic-element ring buffer: the storage of one arm of anira_ring.
 template <typename T>
 using RingBufferT = thl::core::RingBuffer<T>;
 

--- a/include/anira/utils/RingBuffer.h
+++ b/include/anira/utils/RingBuffer.h
@@ -4,6 +4,7 @@
 #include <anira/abi/enums.h>
 #include <tanh/core/RingBuffer.h>
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -23,20 +24,37 @@
  * Every input and output ring of the inference pipeline is one instantiation of
  * thl::core::RingBuffer<T> (anira::RingBufferT<T>), with T the element type of the ring dtype
  * the host declared for the slot on the Hard contract (`anira_contract_hard_set_ring_dtype`;
- * float32 when nothing was declared). This holder owns that instantiation behind a dtype tag,
- * so a std::vector of rings can mix element types, and dispatches every block operation to it.
+ * float32 when nothing was declared). This holder owns that instantiation behind the dtype and
+ * dispatches every block operation to it, so a std::vector of rings can mix element types.
+ *
+ * One rule: one instantiation per scalar dtype the ABI pins, with T the dtype's C type.
+ * float32 -> float, float64 -> double, int8 -> int8_t, uint8 -> uint8_t, int16 -> int16_t,
+ * int32 -> int32_t, int64 -> int64_t; the three dtypes without a C type are stored as their bit
+ * patterns, bool8 as uint8_t and float16 and bfloat16 as uint16_t. No two dtypes share a ring:
+ * a ring initialised as bool8 is a bool8 ring and refuses uint8 data. A dtype with more than one
+ * lane, an opaque or complex dtype is refused at initialize_with_positions(), which is what the
+ * 3.x prepare reports as a configuration error.
  *
  * The rings never convert: what the driver pushes into an input ring is what the pre-processor
  * pops out of it, and what the post-processor pushes into an output ring is what the driver pops
- * out of it, byte for byte (section 7 of the architecture document). The block API therefore
- * takes the caller's dtype beside the data and refuses, returning 0 with nothing written, when
- * it is not the ring's own. The two 16-bit floating-point dtypes are stored as their uint16_t bit
- * patterns: no arithmetic happens on a ring element.
+ * out of it, byte for byte (section 7 of the architecture document); no arithmetic happens on a
+ * ring element. The block API therefore takes the caller's dtype beside the data and refuses,
+ * returning 0 with nothing written, when it is not the ring's own.
  *
- * The nine scalar dtypes the rings store are float32, float16, bfloat16, int8, uint8, bool8,
- * int16, int32 and int64; a dtype with more than one lane, an opaque dtype or float64 is refused
- * at initialize_with_positions(), which is what the 3.x prepare reports as a configuration
- * error.
+ * ABI. This is a C++ type with a std::variant inside: like every 2.x class it is compiled into
+ * the library and into whoever includes this header, so it is not a stable binary interface and
+ * its layout may change with any release. What crosses the ABI is the opaque `anira_ring*` and
+ * the C accessors of `abi/stage.h` (`anira_ring_dtype`, `anira_ring_push_block`, ...), which are
+ * implemented on top of these members inside the library; a 3.x stage pops its samples through
+ * those, or through the `anira.hpp` wrapper over them, never through this struct. The 2.x
+ * pre/post processors of this pre-release use the members directly, as they used the previous
+ * float ring, under the 2.x rule that the library and the plugin are built together.
+ *
+ * Dispatch. The arms live in a std::variant, which holds exactly one of them at a time and
+ * remembers which; std::visit calls the given lambda with the active arm, instantiating the
+ * lambda once per arm at compile time and selecting the arm through the variant's index at run
+ * time. It is one indexed jump per block call: no virtual function, no allocation, nothing that
+ * can block, so it is legal on the driver thread.
  *
  * Semantics of the storage (tanh-lib's Apache-2.0 core component, thl::core::RingBuffer):
  *  - push_sample() into a full channel silently overwrites the oldest sample (the read
@@ -74,14 +92,13 @@ public:
      * @brief Makes this a ring of `dtype`, `num_channels` channels and `num_samples` elements
      * each, cleared.
      *
-     * @return true; false, with the ring left as it was, when `dtype` is not one of the nine
-     * scalar dtypes the rings store (a dtype with more than one lane, an opaque dtype, float64).
+     * @return true; false, with the ring left as it was, when `dtype` is not one of the ten
+     * scalar dtypes the rings store (a dtype with more than one lane, an opaque or complex one).
      */
     bool initialize_with_positions(size_t num_channels, size_t num_samples, anira_dtype dtype) {
         size_t index = 0;
         if (!arm_index_of(dtype, index)) { return false; }
         if (m_storage.index() != index) { emplace_arm(index); }
-        m_dtype = dtype;
         std::visit([&](auto& ring) { ring.initialize_with_positions(num_channels, num_samples); },
                    m_storage);
         return true;
@@ -93,7 +110,7 @@ public:
     }
 
     /// The element type this ring stores (float32 for a ring that was never initialised).
-    [[nodiscard]] anira_dtype dtype() const noexcept { return m_dtype; }
+    [[nodiscard]] anira_dtype dtype() const noexcept { return k_arm_dtypes[m_storage.index()]; }
 
     [[nodiscard]] size_t num_channels() const {
         return std::visit([](const auto& ring) { return ring.get_num_channels(); }, m_storage);
@@ -124,7 +141,7 @@ public:
     /// Pushes `count` elements of `dtype` from `data` into `channel` (the oldest are overwritten
     /// when the ring is full).
     size_t push_block(size_t channel, const void* data, anira_dtype dtype, size_t count) {
-        if (dtype != m_dtype) { return 0; }
+        if (dtype != this->dtype()) { return 0; }
         std::visit(
             [&](auto& ring) {
                 using T = element_t<decltype(ring)>;
@@ -137,7 +154,7 @@ public:
     /// Pops `count` elements of `dtype` from `channel` into `data`; the elements beyond the
     /// available ones are value-initialised.
     size_t pop_block(size_t channel, void* data, anira_dtype dtype, size_t count) {
-        if (dtype != m_dtype) { return 0; }
+        if (dtype != this->dtype()) { return 0; }
         std::visit(
             [&](auto& ring) {
                 using T = element_t<decltype(ring)>;
@@ -150,7 +167,7 @@ public:
     /// Copies the `count` most recently consumed elements of `channel` (history) into `data`,
     /// oldest first, without popping.
     size_t peek_past_block(size_t channel, void* data, anira_dtype dtype, size_t count) const {
-        if (dtype != m_dtype) { return 0; }
+        if (dtype != this->dtype()) { return 0; }
         std::visit(
             [&](const auto& ring) {
                 using T = element_t<decltype(ring)>;
@@ -162,7 +179,7 @@ public:
 
     /// Pushes `count` copies of the element of `dtype` at `value` into `channel`.
     size_t push_fill(size_t channel, const void* value, anira_dtype dtype, size_t count) {
-        if (dtype != m_dtype) { return 0; }
+        if (dtype != this->dtype()) { return 0; }
         std::visit(
             [&](auto& ring) {
                 using T = element_t<decltype(ring)>;
@@ -207,7 +224,7 @@ public:
                        size_t num_old,
                        size_t offset,
                        size_t num_batches) {
-        if (dtype != m_dtype) { return 0; }
+        if (dtype != this->dtype()) { return 0; }
         const size_t window = num_new + num_old;
         std::visit(
             [&](auto& ring) {
@@ -271,15 +288,28 @@ public:
     [[nodiscard]] size_t get_num_samples() const { return capacity(); }
 
 private:
-    // One arm per stored element type; the two 16-bit floats and the two 8-bit unsigned
-    // dtypes share a carrier, told apart by m_dtype.
-    using Storage = std::variant<thl::core::RingBuffer<float>,
-                                 thl::core::RingBuffer<int16_t>,
-                                 thl::core::RingBuffer<int32_t>,
-                                 thl::core::RingBuffer<int8_t>,
-                                 thl::core::RingBuffer<uint8_t>,
-                                 thl::core::RingBuffer<int64_t>,
-                                 thl::core::RingBuffer<uint16_t>>;
+    // One arm per scalar dtype, in the order of k_arm_dtypes: the variant's index is the dtype.
+    using Storage = std::variant<thl::core::RingBuffer<float>,     // float32
+                                 thl::core::RingBuffer<double>,    // float64
+                                 thl::core::RingBuffer<uint16_t>,  // float16, as bits
+                                 thl::core::RingBuffer<uint16_t>,  // bfloat16, as bits
+                                 thl::core::RingBuffer<int8_t>,    // int8
+                                 thl::core::RingBuffer<uint8_t>,   // uint8
+                                 thl::core::RingBuffer<uint8_t>,   // bool8, as bits
+                                 thl::core::RingBuffer<int16_t>,   // int16
+                                 thl::core::RingBuffer<int32_t>,   // int32
+                                 thl::core::RingBuffer<int64_t>>;  // int64
+    static constexpr size_t k_num_arms = std::variant_size_v<Storage>;
+    static constexpr std::array<anira_dtype, k_num_arms> k_arm_dtypes{ANIRA_DTYPE_F32,
+                                                                      ANIRA_DTYPE_F64,
+                                                                      ANIRA_DTYPE_F16,
+                                                                      ANIRA_DTYPE_BF16,
+                                                                      ANIRA_DTYPE_I8,
+                                                                      ANIRA_DTYPE_U8,
+                                                                      ANIRA_DTYPE_BOOL8,
+                                                                      ANIRA_DTYPE_I16,
+                                                                      ANIRA_DTYPE_I32,
+                                                                      ANIRA_DTYPE_I64};
 
     template <typename Ring>
     struct element_of;
@@ -291,40 +321,24 @@ private:
     using element_t = typename element_of<std::remove_cvref_t<Ring>>::type;
 
     static bool arm_index_of(anira_dtype dtype, size_t& index) noexcept {
-        switch (static_cast<uint32_t>(dtype)) {
-            case ANIRA_DTYPE_F32: index = 0; return true;
-            case ANIRA_DTYPE_I16: index = 1; return true;
-            case ANIRA_DTYPE_I32: index = 2; return true;
-            case ANIRA_DTYPE_I8: index = 3; return true;
-            case ANIRA_DTYPE_U8:
-            case ANIRA_DTYPE_BOOL8: index = 4; return true;
-            case ANIRA_DTYPE_I64: index = 5; return true;
-            case ANIRA_DTYPE_F16:
-            case ANIRA_DTYPE_BF16: index = 6; return true;
-            default: return false;
+        for (size_t i = 0; i < k_num_arms; ++i) {
+            if (k_arm_dtypes[i] == dtype) {
+                index = i;
+                return true;
+            }
         }
+        return false;
     }
 
-    void emplace_arm(size_t index) {
-        switch (index) {
-            case 0: m_storage.emplace<0>(); break;
-            case 1: m_storage.emplace<1>(); break;
-            case 2: m_storage.emplace<2>(); break;
-            case 3: m_storage.emplace<3>(); break;
-            case 4: m_storage.emplace<4>(); break;
-            case 5: m_storage.emplace<5>(); break;
-            default: m_storage.emplace<6>(); break;
-        }
+    template <size_t... I>
+    void emplace_arm(size_t index, std::index_sequence<I...> /*arms*/) {
+        ((index == I ? (void)m_storage.emplace<I>() : void()), ...);
     }
+    void emplace_arm(size_t index) { emplace_arm(index, std::make_index_sequence<k_num_arms>{}); }
 
-    thl::core::RingBuffer<float>* f32() noexcept {
-        return m_dtype == ANIRA_DTYPE_F32 ? std::get_if<0>(&m_storage) : nullptr;
-    }
-    const thl::core::RingBuffer<float>* f32() const noexcept {
-        return m_dtype == ANIRA_DTYPE_F32 ? std::get_if<0>(&m_storage) : nullptr;
-    }
+    thl::core::RingBuffer<float>* f32() noexcept { return std::get_if<0>(&m_storage); }
+    const thl::core::RingBuffer<float>* f32() const noexcept { return std::get_if<0>(&m_storage); }
 
-    anira_dtype m_dtype = ANIRA_DTYPE_F32;
     Storage m_storage;  ///< Default-constructed: the float32 arm, no capacity
 };
 // NOLINTEND(readability-identifier-naming)

--- a/src/PrePostProcessor.cpp
+++ b/src/PrePostProcessor.cpp
@@ -1,5 +1,6 @@
 #include <anira/InferenceConfig.h>
 #include <anira/PrePostProcessor.h>
+#include <anira/abi/enums.h>
 #include <anira/utils/Buffer.h>
 #include <anira/utils/InferenceBackend.h>
 #include <anira/utils/RingBuffer.h>
@@ -132,13 +133,16 @@ void PrePostProcessor::pop_samples_from_buffer(RingBuffer& input,
                                                size_t num_old_samples,
                                                size_t offset,
                                                size_t num_batches) {
-    size_t const window_size = num_new_samples + num_old_samples;
-    for (size_t batch = 0; batch < num_batches; ++batch) {
-        pop_samples_from_buffer(input,
-                                output,
-                                num_new_samples,
-                                num_old_samples,
-                                offset + batch * window_size);
+    // The batch loop is the ring's (anira_ring::pop_windows); every channel writes the same
+    // windows, as the single-window overload above does (these are mono windows).
+    for (size_t i = 0; i < input.get_num_channels(); i++) {
+        input.pop_windows(i,
+                          output.get_write_pointer(0, 0),
+                          ANIRA_DTYPE_F32,
+                          num_new_samples,
+                          num_old_samples,
+                          offset,
+                          num_batches);
     }
 }
 

--- a/src/capi/json.cpp
+++ b/src/capi/json.cpp
@@ -147,8 +147,9 @@ const std::array<std::pair<const char*, anira_engine>, 5> k_engines_v2{{
     {"EXECUTORCH", ANIRA_ENGINE_EXECUTORCH},
 }};
 constexpr const char* k_v2_custom_engine = "anira.v2.custom";
-const std::array<std::pair<const char*, anira_dtype>, 9> k_dtypes{{
+const std::array<std::pair<const char*, anira_dtype>, 10> k_dtypes{{
     {"float32", ANIRA_DTYPE_F32},
+    {"float64", ANIRA_DTYPE_F64},
     {"float16", ANIRA_DTYPE_F16},
     {"bfloat16", ANIRA_DTYPE_BF16},
     {"int8", ANIRA_DTYPE_I8},

--- a/src/scheduler/Context.cpp
+++ b/src/scheduler/Context.cpp
@@ -763,7 +763,8 @@ bool Context::release_core_if_idle() {
 
 void Context::prepare_session(const std::shared_ptr<SessionElement>& session,
                               HostConfig new_config,
-                              std::vector<long> custom_latency) {
+                              std::vector<long> custom_latency,
+                              const RingDtypes& ring_dtypes) {
     // seq_cst: pairs with the worker's register-before-check in
     // InferenceThread::process_dequeued_inference().
     session->m_initialized.store(false, std::memory_order::seq_cst);
@@ -779,7 +780,7 @@ void Context::prepare_session(const std::shared_ptr<SessionElement>& session,
 
     drain_inference_queue(session);
 
-    session->prepare(new_config, std::move(custom_latency));
+    session->prepare(new_config, std::move(custom_latency), ring_dtypes);
 
     {
         // Only the pool start touches shared state; the drain and the
@@ -853,10 +854,10 @@ void Context::new_data_submitted(const std::shared_ptr<SessionElement>& session)
                      channel <
                      session->m_inference_config.get_postprocess_output_channels()[tensor_index];
                      channel++) {
-                    // Non-streamable parameters have no output size
-                    session->m_receive_buffer[tensor_index].push_fill(
+                    // Non-streamable parameters have no output size; the zeros are of the
+                    // ring's own element type
+                    session->m_receive_buffer[tensor_index].push_zeros(
                         channel,
-                        0.f,
                         session->m_inference_config.get_postprocess_output_size()[tensor_index]);
                 }
             }

--- a/src/scheduler/Context.cpp
+++ b/src/scheduler/Context.cpp
@@ -763,7 +763,7 @@ bool Context::release_core_if_idle() {
 
 void Context::prepare_session(const std::shared_ptr<SessionElement>& session,
                               HostConfig new_config,
-                              std::vector<long> custom_latency,
+                              const CustomLatencies& custom_latencies,
                               const RingDtypes& ring_dtypes) {
     // seq_cst: pairs with the worker's register-before-check in
     // InferenceThread::process_dequeued_inference().
@@ -780,7 +780,7 @@ void Context::prepare_session(const std::shared_ptr<SessionElement>& session,
 
     drain_inference_queue(session);
 
-    session->prepare(new_config, std::move(custom_latency), ring_dtypes);
+    session->prepare(new_config, custom_latencies, ring_dtypes);
 
     {
         // Only the pool start touches shared state; the drain and the

--- a/src/scheduler/InferenceManager.cpp
+++ b/src/scheduler/InferenceManager.cpp
@@ -4,6 +4,7 @@
 #include <anira/backends/BackendBase.h>
 #include <anira/scheduler/Context.h>
 #include <anira/scheduler/InferenceManager.h>
+#include <anira/scheduler/SessionElement.h>
 #include <anira/utils/HostConfig.h>
 #include <anira/utils/InferenceBackend.h>
 #include <anira/utils/Logger.h>
@@ -42,9 +43,15 @@ InferenceBackend InferenceManager::get_backend() const {
 }
 
 void InferenceManager::prepare(HostConfig new_config, std::vector<long> custom_latency) {
+    prepare(new_config, std::move(custom_latency), RingDtypes{});
+}
+
+void InferenceManager::prepare(HostConfig new_config,
+                               std::vector<long> custom_latency,
+                               const RingDtypes& ring_dtypes) {
     m_host_config = new_config;
 
-    m_context.prepare_session(m_session, m_host_config, std::move(custom_latency));
+    m_context.prepare_session(m_session, m_host_config, std::move(custom_latency), ring_dtypes);
 
     m_missing_samples.clear();
     m_missing_samples.resize(m_inference_config.get_tensor_output_shape().size(), 0);
@@ -189,7 +196,7 @@ size_t* InferenceManager::process_output(float* const* const* output_data, size_
     bool enough_samples = true;
     for (size_t i = 0; i < m_inference_config.get_tensor_output_shape().size(); ++i) {
         if (m_inference_config.get_postprocess_output_size()[i] > 0) {
-            if (m_session->m_receive_buffer[i].get_available_samples(0) < (size_t)num_samples[i]) {
+            if (m_session->m_receive_buffer[i].get_available_samples(0) < num_samples[i]) {
                 enough_samples = false;
                 break;
             }

--- a/src/scheduler/InferenceManager.cpp
+++ b/src/scheduler/InferenceManager.cpp
@@ -43,15 +43,15 @@ InferenceBackend InferenceManager::get_backend() const {
 }
 
 void InferenceManager::prepare(HostConfig new_config, std::vector<long> custom_latency) {
-    prepare(new_config, std::move(custom_latency), RingDtypes{});
+    prepare(new_config, CustomLatencies{std::move(custom_latency)}, RingDtypes{});
 }
 
 void InferenceManager::prepare(HostConfig new_config,
-                               std::vector<long> custom_latency,
+                               const CustomLatencies& custom_latencies,
                                const RingDtypes& ring_dtypes) {
     m_host_config = new_config;
 
-    m_context.prepare_session(m_session, m_host_config, std::move(custom_latency), ring_dtypes);
+    m_context.prepare_session(m_session, m_host_config, custom_latencies, ring_dtypes);
 
     m_missing_samples.clear();
     m_missing_samples.resize(m_inference_config.get_tensor_output_shape().size(), 0);

--- a/src/scheduler/SessionElement.cpp
+++ b/src/scheduler/SessionElement.cpp
@@ -1,5 +1,6 @@
 #include <anira/InferenceConfig.h>
 #include <anira/PrePostProcessor.h>
+#include <anira/abi/enums.h>
 #include <anira/scheduler/LatencyCalculator.h>
 #include <anira/scheduler/SessionElement.h>
 #include <anira/utils/HostConfig.h>
@@ -23,11 +24,15 @@
 #endif
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <memory>
+#include <stdexcept>
+#include <string>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -94,9 +99,8 @@ void SessionElement::clear() {
     for (size_t i = 0; i < m_inference_config.get_tensor_output_shape().size(); ++i) {
         if (m_inference_config.get_postprocess_output_size()[i] > 0 && m_latency[i] > 0) {
             for (size_t j = 0; j < m_inference_config.get_postprocess_output_channels()[i]; ++j) {
-                m_receive_buffer[i].push_fill(
+                m_receive_buffer[i].push_zeros(
                     j,
-                    0.f,
                     m_latency[i] - m_inference_config.get_internal_model_latency()[i]);
             }
         }
@@ -247,7 +251,9 @@ void SessionElement::complete_with_zeros(
     }
 }
 
-void SessionElement::prepare(const HostConfig& host_config, std::vector<long> custom_latency) {
+void SessionElement::prepare(const HostConfig& host_config,
+                             std::vector<long> custom_latency,
+                             const RingDtypes& ring_dtypes) {
     // Resolve the reference stream first: an unresolvable host config throws before any
     // session state is touched. The result is read on the real-time path and never
     // re-resolved there.
@@ -322,32 +328,54 @@ void SessionElement::prepare(const HostConfig& host_config, std::vector<long> cu
     m_send_buffer.resize(m_inference_config.get_tensor_input_shape().size());
     m_receive_buffer.resize(m_inference_config.get_tensor_output_shape().size());
 
+    // Every ring stores the element type of its slot's ring dtype (float32 unless the host
+    // declared another one); the sizes above are element counts, so they are the same whatever
+    // the type. A dtype the rings cannot store is a configuration error, like an unresolvable
+    // reference stream.
+    const auto ring_dtype = [](const std::vector<anira_dtype>& dtypes, size_t slot) {
+        return slot < dtypes.size() ? dtypes[slot] : ANIRA_DTYPE_F32;
+    };
+    const auto refuse = [](const char* side, size_t slot, anira_dtype dtype) {
+        std::array<char, 16> code{};
+        (void)std::snprintf(code.data(), code.size(), "0x%x", static_cast<unsigned>(dtype));
+        throw std::invalid_argument(std::string("SessionElement::prepare: the ring dtype ") +
+                                    code.data() + " of " + side + " " + std::to_string(slot) +
+                                    " is not a scalar dtype the rings store (float32, float16, "
+                                    "bfloat16, int8, uint8, bool8, int16, int32 or int64)");
+    };
     for (size_t i = 0; i < m_inference_config.get_tensor_input_shape().size(); ++i) {
+        const anira_dtype dtype = ring_dtype(ring_dtypes.m_inputs, i);
         if (m_send_buffer_size[i] > 0) {
-            m_send_buffer[i].initialize_with_positions(
-                m_inference_config.get_preprocess_input_channels()[i],
-                m_send_buffer_size[i]);
+            if (!m_send_buffer[i].initialize_with_positions(
+                    m_inference_config.get_preprocess_input_channels()[i],
+                    m_send_buffer_size[i],
+                    dtype)) {
+                refuse("input", i, dtype);
+            }
         } else {
             m_send_buffer[i].clear_with_positions();
         }
     }
     for (size_t i = 0; i < m_inference_config.get_tensor_output_shape().size(); ++i) {
+        const anira_dtype dtype = ring_dtype(ring_dtypes.m_outputs, i);
         if (m_receive_buffer_size[i] > 0) {
-            m_receive_buffer[i].initialize_with_positions(
-                m_inference_config.get_postprocess_output_channels()[i],
-                m_receive_buffer_size[i]);
+            if (!m_receive_buffer[i].initialize_with_positions(
+                    m_inference_config.get_postprocess_output_channels()[i],
+                    m_receive_buffer_size[i],
+                    dtype)) {
+                refuse("output", i, dtype);
+            }
         } else {
             m_receive_buffer[i].clear_with_positions();
         }
     }
 
-    // Push back 0.f for latency
+    // Prime the latency with zeros of the ring's own element type
     for (size_t i = 0; i < m_inference_config.get_tensor_output_shape().size(); ++i) {
         if (m_latency[i] > 0) {
             for (size_t j = 0; j < m_inference_config.get_postprocess_output_channels()[i]; ++j) {
-                m_receive_buffer[i].push_fill(
+                m_receive_buffer[i].push_zeros(
                     j,
-                    0.f,
                     m_latency[i] - m_inference_config.get_internal_model_latency()[i]);
             }
         }

--- a/src/scheduler/SessionElement.cpp
+++ b/src/scheduler/SessionElement.cpp
@@ -252,8 +252,9 @@ void SessionElement::complete_with_zeros(
 }
 
 void SessionElement::prepare(const HostConfig& host_config,
-                             std::vector<long> custom_latency,
+                             const CustomLatencies& custom_latencies,
                              const RingDtypes& ring_dtypes) {
+    const std::vector<long>& custom_latency = custom_latencies.m_outputs;
     // Resolve the reference stream first: an unresolvable host config throws before any
     // session state is touched. The result is read on the real-time path and never
     // re-resolved there.

--- a/test/scheduler/test_SessionElement.cpp
+++ b/test/scheduler/test_SessionElement.cpp
@@ -1,5 +1,6 @@
 #include <anira/InferenceConfig.h>
 #include <anira/PrePostProcessor.h>
+#include <anira/abi/enums.h>
 #include <anira/scheduler/SessionElement.h>
 #include <anira/utils/HostConfig.h>
 #include <anira/utils/InferenceBackend.h>
@@ -14,6 +15,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <iomanip>
 #include <ios>
 #include <ostream>
@@ -110,6 +112,52 @@ TEST_P(SessionElementTest, LatencyStructAndRingbuffers) {
             << ". Expected: " << test_params.m_expected_receive_buffer_sizes[i]
             << ", Got: " << session_element.m_receive_buffer_size[i];
     }
+}
+
+// The rings store the element type of their slot's ring dtype: a slot named int16 gets an int16
+// ring of the same element count as the float run (the sizes are element counts), a slot not
+// named stays float32, the latency priming is zeros of the ring's own type, and a dtype the
+// rings cannot store is refused like an unresolvable reference stream.
+TEST(SessionElementRingDtypes, ASlotsRingHoldsItsRingDtype) {
+    InferenceConfig config({ModelData("placeholder", InferenceBackend::CUSTOM)},
+                           {TensorShape({{1, 1, 512}}, {{1, 1, 512}})},
+                           5.0F);
+    PrePostProcessor pp_processor(config);
+    InferenceQueue inference_queue;
+    const HostConfig host_config(512, 48000.0);
+
+    SessionElement floats(0, pp_processor, config, moodycamel::ProducerToken(inference_queue));
+    floats.prepare(host_config);
+    ASSERT_EQ(floats.m_send_buffer[0].dtype(), ANIRA_DTYPE_F32);
+    ASSERT_EQ(floats.m_receive_buffer[0].dtype(), ANIRA_DTYPE_F32);
+
+    RingDtypes dtypes;
+    dtypes.m_inputs = {ANIRA_DTYPE_I16};
+    SessionElement int16_in(1, pp_processor, config, moodycamel::ProducerToken(inference_queue));
+    int16_in.prepare(host_config, {}, dtypes);
+    EXPECT_EQ(int16_in.m_send_buffer[0].dtype(), ANIRA_DTYPE_I16);
+    EXPECT_EQ(int16_in.m_receive_buffer[0].dtype(), ANIRA_DTYPE_F32) << "not named: float32";
+    EXPECT_EQ(int16_in.m_send_buffer_size, floats.m_send_buffer_size);
+    EXPECT_EQ(int16_in.m_receive_buffer_size, floats.m_receive_buffer_size);
+    EXPECT_EQ(int16_in.m_send_buffer[0].capacity(), floats.m_send_buffer[0].capacity());
+    EXPECT_EQ(int16_in.m_send_buffer[0].num_channels(), floats.m_send_buffer[0].num_channels());
+
+    dtypes = RingDtypes{};
+    dtypes.m_outputs = {ANIRA_DTYPE_I16};
+    SessionElement int16_out(2, pp_processor, config, moodycamel::ProducerToken(inference_queue));
+    int16_out.prepare(host_config, {}, dtypes);
+    EXPECT_EQ(int16_out.m_receive_buffer[0].dtype(), ANIRA_DTYPE_I16);
+    EXPECT_EQ(int16_out.m_receive_buffer[0].capacity(), floats.m_receive_buffer[0].capacity());
+    EXPECT_EQ(int16_out.m_receive_buffer[0].available(0), floats.m_receive_buffer[0].available(0))
+        << "the latency priming is the same element count, typed";
+    int16_t primed = 7;
+    ASSERT_EQ(int16_out.m_receive_buffer[0].pop_block(0, &primed, ANIRA_DTYPE_I16, 1), 1U);
+    EXPECT_EQ(primed, 0);
+
+    dtypes = RingDtypes{};
+    dtypes.m_inputs = {ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 32, 4)};
+    SessionElement lanes(3, pp_processor, config, moodycamel::ProducerToken(inference_queue));
+    EXPECT_THROW(lanes.prepare(host_config, {}, dtypes), std::invalid_argument);
 }
 
 namespace {

--- a/test/utils/test_RingBuffer.cpp
+++ b/test/utils/test_RingBuffer.cpp
@@ -1,3 +1,4 @@
+#include <anira/abi/enums.h>
 #include <anira/utils/RingBuffer.h>
 
 #include <array>
@@ -60,4 +61,174 @@ TEST_F(RingBufferTest, DimensionsAndTypedVariant) {
     const int64_t big = (1LL << 40) + 7;  // exact beyond float32's 2^24 range
     tokens.push_sample(0, big);
     EXPECT_EQ(tokens.pop_sample(0), big);
+}
+// ---- The typed rings: one instantiation per scalar dtype behind anira_ring -------------------
+
+namespace {
+
+// Push, pop, peek, fill, discard and the batched window pop over one channel of a ring of
+// `dtype`, stored as `T`; a call with another dtype moves nothing.
+template <typename T>
+void round_trip(anira_dtype dtype) {
+    anira::RingBuffer ring;
+    ASSERT_TRUE(ring.initialize_with_positions(2, 8, dtype));
+    EXPECT_EQ(ring.dtype(), dtype);
+    EXPECT_EQ(ring.num_channels(), 2U);
+    EXPECT_EQ(ring.capacity(), 8U);
+    EXPECT_EQ(ring.available(1), 0U);
+
+    const std::array<T, 5> in{T(1), T(2), T(3), T(4), T(5)};
+    EXPECT_EQ(ring.push_block(1, in.data(), dtype, in.size()), 5U);
+    EXPECT_EQ(ring.available(1), 5U);
+    EXPECT_EQ(ring.available(0), 0U) << "channels are independent";
+
+    std::array<T, 3> out{};
+    EXPECT_EQ(ring.pop_block(1, out.data(), dtype, out.size()), 3U);
+    EXPECT_EQ(out[0], T(1));
+    EXPECT_EQ(out[2], T(3));
+    EXPECT_EQ(ring.available(1), 2U);
+    EXPECT_EQ(ring.available_past(1), 3U);
+
+    std::array<T, 3> past{};
+    EXPECT_EQ(ring.peek_past_block(1, past.data(), dtype, past.size()), 3U);
+    EXPECT_EQ(past[0], T(1)) << "oldest first";
+    EXPECT_EQ(past[2], T(3)) << "the sample popped last";
+
+    const T seven = T(7);
+    EXPECT_EQ(ring.push_fill(1, &seven, dtype, 2), 2U);
+    EXPECT_EQ(ring.available(1), 4U);
+    EXPECT_EQ(ring.discard(1, 1), 1U);  // drops T(4)
+    EXPECT_EQ(ring.available(1), 3U);   // T(5), T(7), T(7)
+
+    // Two windows of one old and one new element each: [4 5] then [5 7].
+    std::array<T, 4> windows{};
+    EXPECT_EQ(ring.pop_windows(1, windows.data(), dtype, 1, 1, 0, 2), 4U);
+    EXPECT_EQ(windows[0], T(4));
+    EXPECT_EQ(windows[1], T(5));
+    EXPECT_EQ(windows[2], T(5));
+    EXPECT_EQ(windows[3], T(7));
+    EXPECT_EQ(ring.available(1), 1U);
+
+    EXPECT_EQ(ring.push_zeros(0, 3), 3U);
+    std::array<T, 3> zeros{T(9), T(9), T(9)};
+    EXPECT_EQ(ring.pop_block(0, zeros.data(), dtype, zeros.size()), 3U);
+    EXPECT_EQ(zeros[0], T{});
+    EXPECT_EQ(zeros[2], T{});
+
+    // Another dtype moves nothing and writes nothing.
+    const anira_dtype other = dtype == ANIRA_DTYPE_F32 ? ANIRA_DTYPE_I16 : ANIRA_DTYPE_F32;
+    std::array<T, 2> untouched{T(42), T(42)};
+    EXPECT_EQ(ring.pop_block(1, untouched.data(), other, untouched.size()), 0U);
+    EXPECT_EQ(untouched[0], T(42));
+    EXPECT_EQ(ring.push_block(1, in.data(), other, 2), 0U);
+    EXPECT_EQ(ring.peek_past_block(1, untouched.data(), other, 1), 0U);
+    EXPECT_EQ(ring.push_fill(1, &seven, other, 2), 0U);
+    EXPECT_EQ(ring.pop_windows(1, untouched.data(), other, 1, 1, 0, 1), 0U);
+    EXPECT_EQ(untouched[1], T(42));
+    EXPECT_EQ(ring.available(1), 1U);
+
+    ring.clear_with_positions();
+    EXPECT_EQ(ring.dtype(), dtype) << "clear keeps the dtype";
+    EXPECT_EQ(ring.capacity(), 8U) << "clear keeps the capacity";
+    EXPECT_EQ(ring.available(1), 0U);
+}
+
+}  // namespace
+
+TEST(RingBufferTyped, Float32) {
+    round_trip<float>(ANIRA_DTYPE_F32);
+}
+TEST(RingBufferTyped, Float16IsStoredAsItsBits) {
+    round_trip<uint16_t>(ANIRA_DTYPE_F16);
+}
+TEST(RingBufferTyped, BFloat16IsStoredAsItsBits) {
+    round_trip<uint16_t>(ANIRA_DTYPE_BF16);
+}
+TEST(RingBufferTyped, Int8) {
+    round_trip<int8_t>(ANIRA_DTYPE_I8);
+}
+TEST(RingBufferTyped, UInt8) {
+    round_trip<uint8_t>(ANIRA_DTYPE_U8);
+}
+TEST(RingBufferTyped, Bool8) {
+    round_trip<uint8_t>(ANIRA_DTYPE_BOOL8);
+}
+TEST(RingBufferTyped, Int16) {
+    round_trip<int16_t>(ANIRA_DTYPE_I16);
+}
+TEST(RingBufferTyped, Int32) {
+    round_trip<int32_t>(ANIRA_DTYPE_I32);
+}
+TEST(RingBufferTyped, Int64) {
+    round_trip<int64_t>(ANIRA_DTYPE_I64);
+}
+
+TEST(RingBufferTyped, TheCarrierDtypeIsTheOneAsked) {
+    // uint8 and bool8 share a carrier, as do float16 and bfloat16: the ring reports the dtype
+    // it was initialised with and refuses the sibling.
+    anira::RingBuffer ring;
+    ASSERT_TRUE(ring.initialize_with_positions(1, 4, ANIRA_DTYPE_BOOL8));
+    EXPECT_EQ(ring.dtype(), ANIRA_DTYPE_BOOL8);
+    const uint8_t yes = 1;
+    EXPECT_EQ(ring.push_fill(0, &yes, ANIRA_DTYPE_U8, 1), 0U);
+    EXPECT_EQ(ring.push_fill(0, &yes, ANIRA_DTYPE_BOOL8, 1), 1U);
+    ASSERT_TRUE(ring.initialize_with_positions(1, 4, ANIRA_DTYPE_BF16));
+    EXPECT_EQ(ring.dtype(), ANIRA_DTYPE_BF16);
+    const uint16_t bits = 0x3f80;  // 1.0 as bfloat16
+    EXPECT_EQ(ring.push_fill(0, &bits, ANIRA_DTYPE_F16, 1), 0U);
+    EXPECT_EQ(ring.push_fill(0, &bits, ANIRA_DTYPE_BF16, 1), 1U);
+    uint16_t back = 0;
+    EXPECT_EQ(ring.pop_block(0, &back, ANIRA_DTYPE_BF16, 1), 1U);
+    EXPECT_EQ(back, bits) << "no arithmetic happens on a ring element";
+}
+
+TEST(RingBufferTyped, DtypesTheRingsCannotStoreAreRefusedAtInitialize) {
+    anira::RingBuffer ring;
+    ring.initialize_with_positions(1, 4);
+    ring.push_sample(0, 1.0F);
+    EXPECT_FALSE(ring.initialize_with_positions(1, 4, ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 32, 4)))
+        << "lanes > 1";
+    EXPECT_FALSE(ring.initialize_with_positions(1, 4, ANIRA_MAKE_DTYPE(ANIRA_DTYPE_OPAQUE, 64, 1)));
+    EXPECT_FALSE(ring.initialize_with_positions(1, 4, ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 64, 1)))
+        << "float64";
+    EXPECT_EQ(ring.dtype(), ANIRA_DTYPE_F32) << "the ring is left as it was";
+    EXPECT_EQ(ring.available(0), 1U);
+    EXPECT_FLOAT_EQ(ring.pop_sample(0), 1.0F);
+}
+
+TEST(RingBufferTyped, TheFloatFaceIsTheFloat32Arm) {
+    anira::RingBuffer ring;
+    ASSERT_TRUE(ring.initialize_with_positions(1, 4, ANIRA_DTYPE_I16));
+    const int16_t value = 3;
+    EXPECT_EQ(ring.push_block(0, &value, ANIRA_DTYPE_I16, 1), 1U);
+
+    // The 2.x float calls do nothing on an int16 ring; the counts are dtype-independent.
+    ring.push_sample(0, 1.0F);
+    EXPECT_EQ(ring.get_available_samples(0), 1U);
+    EXPECT_FLOAT_EQ(ring.pop_sample(0), 0.0F);
+    EXPECT_EQ(ring.get_available_samples(0), 1U) << "nothing was popped";
+    std::array<float, 2> floats{5.0F, 5.0F};
+    ring.pop_block(0, floats.data(), floats.size());
+    EXPECT_FLOAT_EQ(floats[0], 5.0F) << "nothing was written";
+    EXPECT_FLOAT_EQ(ring.get_future_sample(0, 0), 0.0F);
+    EXPECT_FLOAT_EQ(ring.get_past_sample(0, 1), 0.0F);
+    EXPECT_EQ(ring.get_num_channels(), 1U);
+    EXPECT_EQ(ring.get_num_samples(), 4U);
+
+    // The two-argument initialise is the float face: the ring is float32 again.
+    ring.initialize_with_positions(1, 4);
+    EXPECT_EQ(ring.dtype(), ANIRA_DTYPE_F32);
+    ring.push_sample(0, 2.0F);
+    ring.push_sample(0, 3.0F);
+    EXPECT_FLOAT_EQ(ring.get_future_sample(0, 1), 3.0F);
+    EXPECT_FLOAT_EQ(ring.pop_sample(0), 2.0F);
+    EXPECT_FLOAT_EQ(ring.get_past_sample(0, 1), 2.0F);
+}
+
+TEST(RingBufferTyped, ADefaultConstructedRingIsAnEmptyFloat32Ring) {
+    // std::vector<anira::RingBuffer> input(1) and the like rely on it.
+    const anira::RingBuffer ring;
+    EXPECT_EQ(ring.dtype(), ANIRA_DTYPE_F32);
+    EXPECT_EQ(ring.capacity(), 0U);
+    EXPECT_EQ(ring.num_channels(), 0U);
 }

--- a/test/utils/test_RingBuffer.cpp
+++ b/test/utils/test_RingBuffer.cpp
@@ -138,6 +138,9 @@ void round_trip(anira_dtype dtype) {
 TEST(RingBufferTyped, Float32) {
     round_trip<float>(ANIRA_DTYPE_F32);
 }
+TEST(RingBufferTyped, Float64) {
+    round_trip<double>(ANIRA_DTYPE_F64);
+}
 TEST(RingBufferTyped, Float16IsStoredAsItsBits) {
     round_trip<uint16_t>(ANIRA_DTYPE_F16);
 }
@@ -163,9 +166,9 @@ TEST(RingBufferTyped, Int64) {
     round_trip<int64_t>(ANIRA_DTYPE_I64);
 }
 
-TEST(RingBufferTyped, TheCarrierDtypeIsTheOneAsked) {
-    // uint8 and bool8 share a carrier, as do float16 and bfloat16: the ring reports the dtype
-    // it was initialised with and refuses the sibling.
+TEST(RingBufferTyped, EveryDtypeIsItsOwnRing) {
+    // uint8 and bool8 store the same bytes, as do float16 and bfloat16, but no two dtypes share
+    // a ring: the ring reports the dtype it was initialised with and refuses the sibling.
     anira::RingBuffer ring;
     ASSERT_TRUE(ring.initialize_with_positions(1, 4, ANIRA_DTYPE_BOOL8));
     EXPECT_EQ(ring.dtype(), ANIRA_DTYPE_BOOL8);
@@ -189,8 +192,10 @@ TEST(RingBufferTyped, DtypesTheRingsCannotStoreAreRefusedAtInitialize) {
     EXPECT_FALSE(ring.initialize_with_positions(1, 4, ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 32, 4)))
         << "lanes > 1";
     EXPECT_FALSE(ring.initialize_with_positions(1, 4, ANIRA_MAKE_DTYPE(ANIRA_DTYPE_OPAQUE, 64, 1)));
-    EXPECT_FALSE(ring.initialize_with_positions(1, 4, ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 64, 1)))
-        << "float64";
+    EXPECT_FALSE(
+        ring.initialize_with_positions(1, 4, ANIRA_MAKE_DTYPE(ANIRA_DTYPE_COMPLEX, 64, 1)));
+    EXPECT_FALSE(ring.initialize_with_positions(1, 4, ANIRA_MAKE_DTYPE(ANIRA_DTYPE_FLOAT, 128, 1)))
+        << "a width no dtype has";
     EXPECT_EQ(ring.dtype(), ANIRA_DTYPE_F32) << "the ring is left as it was";
     EXPECT_EQ(ring.available(0), 1U);
     EXPECT_FLOAT_EQ(ring.pop_sample(0), 1.0F);

--- a/web/src/abi/enums.ts
+++ b/web/src/abi/enums.ts
@@ -324,6 +324,7 @@ export const ANIRA_DTYPE_CODE = (d: number): number => d & 0xff
 export const ANIRA_DTYPE_BITS = (d: number): number => (d >>> 8) & 0xff
 export const ANIRA_DTYPE_LANES = (d: number): number => d >>> 16
 export const ANIRA_DTYPE_F32 = 0x00012002
+export const ANIRA_DTYPE_F64 = 0x00014002
 export const ANIRA_DTYPE_F16 = 0x00011002
 export const ANIRA_DTYPE_BF16 = 0x00011004
 export const ANIRA_DTYPE_I8 = 0x00010800


### PR DESCRIPTION
First PR of M2 (`docs/anira-v3-architecture.md`, section 11, "Tensor and the Host-only pump"; the plan's PR 1), against `v3`. Internal apart from one appended dtype constant: the whole 2.x surface compiles unchanged.

## Summary

- **Every ring is an instantiation of `RingBufferT<T>` with `T` the slot's ring dtype.** `include/anira/utils/RingBuffer.h` no longer aliases `thl::core::RingBuffer<float>`; it defines `anira_ring` (the C tag the 3.x ring accessors of `abi/stage.h` will take), a holder over one `thl::core::RingBuffer<T>` per scalar dtype the ABI pins, chosen at `initialize_with_positions(channels, count, dtype)`. One rule: `T` is the dtype's C type (float, double, int8_t, uint8_t, int16_t, int32_t, int64_t); the three dtypes without one are stored as their bits (bool8 as uint8_t, float16 and bfloat16 as uint16_t); no two dtypes share a ring. A dtype with more than one lane, an opaque or complex one is refused there (`false`, the ring untouched), which is what the 3.x prepare will report as a configuration error. `anira::RingBuffer` names this type; `anira::RingBufferT<T>` stays.
- **`ANIRA_DTYPE_F64`** joins the pinned dtypes (registry, `enums.h`, `enums.ts`, `"float64"` in the JSON vocabulary), so the rings store doubles.
- **A dtype-checked block API that never converts:** `push_block`, `pop_block`, `peek_past_block`, `push_fill`, `push_zeros`, `discard` and `pop_windows` (the batched sliding-window pop of `PrePostProcessor::pop_samples_from_buffer`, moved into the ring) take the caller's dtype beside the data and return 0 with nothing written on a disagreement. `dtype()`, `num_channels()`, `capacity()`, `available()`, `available_past()` read the holder.
- **The 2.x float API stays as the float32 face** (`push_sample`, `pop_sample`, the float block calls, `get_future_sample`, `get_past_sample`, the two-argument `initialize_with_positions`, the `get_*` counts): inline forwarders onto the float arm, a no-op returning 0 on a ring of another dtype, so `PrePostProcessor`'s virtual signatures, the extras processors, the tests, the install consumer and `src/emscripten-wrappers/utils/RingBuffer.cpp` compile unchanged.
- **Per-slot ring dtypes and the caller's latencies reach prepare as named structs.** `anira::RingDtypes` (two `std::vector<anira_dtype>`, a slot not named is float32) and `anira::CustomLatencies` (the former `std::vector<long>`, one entry per output) go through `SessionElement::prepare`, `Context::prepare_session` and a new internal `InferenceManager::prepare(config, custom_latencies, ring_dtypes)` overload; the public 2.x `prepare` converts its vector and passes float32 everywhere. The ring sizes stay `LatencyCalculator`'s element counts. The latency priming and the miss-path zeros are typed (`push_zeros`).
- **ABI position, stated in the header.** `anira_ring` is a C++ type like every 2.x class: compiled into the library and into whoever includes it, not a stable binary interface. What crosses the ABI is the opaque `anira_ring*` with the C accessors of `abi/stage.h` (PR 6), implemented on these members inside the library; a 3.x stage pops through those or through the `anira.hpp` wrapper. The `std::visit` dispatch is one indexed jump per block call, no virtual function, no allocation.

## Tests

- `test_RingBuffer`: a round trip per dtype, float64 included (push, pop, peek, fill, discard, `pop_windows`, `push_zeros`, then a call with another dtype that moves nothing), the sibling dtypes (uint8/bool8, float16/bfloat16) as separate rings, the refusals at initialize, the float face on an int16 ring, the default-constructed ring as an empty float32 ring.
- `test_SessionElement`: an int16 input slot gets an int16 send ring of the same element count as the float run, an unnamed slot stays float32, an int16 output ring is primed with typed zeros, a four-lane dtype is refused with `std::invalid_argument`.
- Everything else is unchanged and green: the default is float32 for every slot.

## Verification (local, after the review round)

- full-engine Debug tree (LibTorch, ONNX Runtime, LiteRT): 486 of 486
- engine-less static tree: 460 of 460
- RTSan tree, the handler, scheduler and utils suites: 300 of 300 (before the review round; the dispatch code is unchanged)
- WebAssembly build (`wasm-release`): builds (`AniraWeb.wasm` 17.3 MB) and `npm run build` passes on it
- benchmark tree: `Benchmark.{Advanced,CNNSize,Simple}` 3 of 3, no regression against the alpha.1-era run
- clang-format clean, clang-tidy clean on the changed sources, `python3 tools/abi/gen.py --repo . --check` clean